### PR TITLE
Possible bug for logical right shift

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -1172,25 +1172,25 @@ int leftShift(int n, int b) {
 }
 
 int rightShift(int n, int b) {
-    // assert: b >= 0            
+    // assert: b >= 0
 
     if (n >= 0)
-        if (b > 30)
-            return 0;
-        else
+        if (b < 31)
             return n / twoToThePowerOf(b);
-    else      
-        if (b > 31)
-            return 0;
-        // in case we shift a negative signed integer by 31 bits:
-        // we can't use below routine since twoToThePowerOf(31) is out of range
-        if (b == 31)
-            return 1;
         else
+            return 0;
+    else
+        if (b < 31)
             // works even if n == INT_MIN:
             // shift right n with msb reset and then restore msb
             return ((n + 1) + INT_MAX) / twoToThePowerOf(b) +
                 (INT_MAX / twoToThePowerOf(b) + 1);
+        else if (b == 31)
+            // in case we shift a negative signed integer by 31 bits:
+            // we can't use preceding routine since twoToThePowerOf(31) is out of range
+            return 1;
+        else
+            return 0;
 }
 
 int loadCharacter(int *s, int i) {

--- a/selfie.c
+++ b/selfie.c
@@ -1172,17 +1172,25 @@ int leftShift(int n, int b) {
 }
 
 int rightShift(int n, int b) {
-    // assert: b >= 0
+    // assert: b >= 0            
 
-    if (b > 30)
-        return 0;
-    else if (n >= 0)
-        return n / twoToThePowerOf(b);
-    else
-        // works even if n == INT_MIN:
-        // shift right n with msb reset and then restore msb
-        return ((n + 1) + INT_MAX) / twoToThePowerOf(b) +
-            (INT_MAX / twoToThePowerOf(b) + 1);
+    if (n >= 0)
+        if (b > 30)
+            return 0;
+        else
+            return n / twoToThePowerOf(b);
+    else      
+        if (b > 31)
+            return 0;
+        // in case we shift a negative signed integer by 31 bits:
+        // we can't use below routine since twoToThePowerOf(31) is out of range
+        if (b == 31)
+            return 1;
+        else
+            // works even if n == INT_MIN:
+            // shift right n with msb reset and then restore msb
+            return ((n + 1) + INT_MAX) / twoToThePowerOf(b) +
+                (INT_MAX / twoToThePowerOf(b) + 1);
 }
 
 int loadCharacter(int *s, int i) {


### PR DESCRIPTION
When shifting a signed integer n, where n<0, by 31 bits the current return value would result in 0.
This happens because rightShift(int n, int b) is set to return 0 whenever b is greater than 30.
Actually the shift should result in 1, since we see the number as a normal bit sequence when logically shifting, as far as I can conclude from the implementation.
Probably this is not that a big problem, since I did not see this case happen in selfie.c. But it should be considered, for completeness.
If this holds, the same goes for leftShift(int n, int b). When shifting an odd number by 31 bits logically to the left, the result should be INT_MIN, not 0.