### PR TITLE
Add comments for Windows' flag values

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -163,14 +163,19 @@ int* string_buffer;    // buffer for string output
 int* filename_buffer;  // buffer for filenames
 int* io_buffer;        // buffer for binary I/O
 
-// 0 = O_RDONLY (0x0000)
-int O_RDONLY = 0;
+// flags for opening read-only files
+// UNIX: 0     = O_RDONLY (0x0000)
+// WIN : 32768 = 0x8000 = _O_BINARY (0x8000) | _O_RDONLY (0x0000)
+int O_RDONLY = 0; //~ Platform-specific
 
-// 577 = 0x0241 = O_CREAT (0x0040) | O_WRONLY (0x0001) | O_TRUNC (0x0200)
-int O_CREAT_WRONLY_TRUNC = 577; // flags for opening write-only files
+// flags for opening write-only files
+// UNIX: 577   = 0x0241 = O_CREAT (0x0040) | O_WRONLY (0x0001) | O_TRUNC (0x0200)
+// WIN : 33537 = 0x8301 = _O_BINARY (0x8000) | _O_CREAT (0x0100) | _O_WRONLY (0x0001) | _O_TRUNC (0x0200)
+int O_CREAT_WRONLY_TRUNC = 577; //~ Platform-specific
 
+// flags for rw-r--r-- file permissions
 // 420 = 00644 = S_IRUSR (00400) | S_IWUSR (00200) | S_IRGRP (00040) | S_IROTH (00004)
-int S_IRUSR_IWUSR_IRGRP_IROTH = 420; // flags for rw-r--r-- file permissions
+int S_IRUSR_IWUSR_IRGRP_IROTH = 420;
 
 // ------------------------ GLOBAL VARIABLES -----------------------
 


### PR DESCRIPTION
Windows needs different file flags to achieve the same behavior as on UNIX. These flag values and their composition have been added above of affected variables. Also, affected variables are "marked" by a trailing "//~ Platform-specific" for an easier discovery.