### PR TITLE
Fixed clean target for the Windows plattform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ clean:
 	rm -rf *.m
 	rm -rf *.s
 	rm -rf selfie
+	rm -rf selfie.exe


### PR DESCRIPTION
When compiling selfie on the windows plattform (gcc mingw), the artifact get's the name selfie.exe. For this reason, the clean target doesn't work.