### PR TITLE
Minor fix for wrong dash formatting on Leanpub.

### DIFF
--- a/manuscript/semantics.md
+++ b/manuscript/semantics.md
@@ -268,7 +268,7 @@ Try the `-s` option to have selfie generate assembly as follows:
 The part of selfie that generates assembly is called a *disassembler*.
 
 [Disassembler](https://en.wikipedia.org/wiki/Disassembler)
-: A computer program that translates machine language into assembly language — the inverse operation to that of an assembler.
+: A computer program that translates machine language into assembly language -- the inverse operation to that of an assembler.
 
 Selfie does not implement an assembler though. The starc compiler simply generates machine code right away without going through assembly first (which would then require an assembler to generate machine code from that assembly).
 

--- a/manuscript/state.md
+++ b/manuscript/state.md
@@ -44,7 +44,7 @@ The programming language C of which we use a tiny subset here was originally des
 Imperative programming is supported by many programming languages but it is not the only programming paradigm. *Declarative programming* is an important alternative that is also supported by many programming languages but handles program state differently.
 
 [Declarative Programming](https://en.wikipedia.org/wiki/Declarative_programming)
-: A programming paradigm — a style of building the structure and elements of computer programs — that expresses the logic of a computation without describing its control flow.
+: A programming paradigm -- a style of building the structure and elements of computer programs -- that expresses the logic of a computation without describing its control flow.
 
 Intuitively, rather than saying imperatively how to change state, declarative programming focuses on declaring what needs to change. While spelling out how to change state can become tedious with imperative programming spelling out what to change can become burdensome with declarative programming. Yet both paradigms have their important use cases and a port of selfie to a declarative programming language would be very nice to have but remains future work for now.
 


### PR DESCRIPTION
Fixed multiple occurrences of dashes that are not properly shown on Leanpub with help from [Jitterted's Guide to Leanpub Formatting
](https://github.com/tedyoung/leanpub-formatting/blob/master/Special_Characters.md#dashes-en-and-em) .