### PR TITLE
Fix for wrong line numbers in error messages [Windows only]

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -1882,7 +1882,7 @@ int findNextCharacter() {
 
     } else if (isCharacterWhitespace()) {
       // keep track of line numbers for error reporting and code annotation
-      if (isCharacterNewLine())
+      if (character == CHAR_LF)
         lineNumber = lineNumber + 1;
 
       // count line feed and carriage return as ignored characters


### PR DESCRIPTION
On Windows, every line ends with a CR and a LF character. For this reason every line get's counted twice, which leads to wrong line numbers in every error message. It's sufficent to count the LF chars. (according to [https://de.wikipedia.org/wiki/Zeilenumbruch#ASCII](wikipedia)).