### PR TITLE
Fixed signed integer overflow in atoi()

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -106,8 +106,8 @@ int  stringLength(int* s);
 void stringReverse(int* s);
 int  stringCompare(int* s, int* t);
 
-int safeAddition(int n, int c);
-int safeMultiplication(int n, int c);
+int checkedAddition(int n, int c);
+int checkedMultiplication(int n, int c);
 
 int  atoi(int* s);
 int* itoa(int n, int* s, int b, int a, int p);
@@ -1412,7 +1412,7 @@ int stringCompare(int* s, int* t) {
       return 0;
 }
 
-int safeAddition(int n, int c) {
+int checkedAddition(int n, int c) {
   // assert: n > INT_MIN && c >= 0
 
   if (n <= INT_MAX - c)
@@ -1423,14 +1423,14 @@ int safeAddition(int n, int c) {
     return -1;
 }
 
-int safeMultiplication(int n, int c) {
+int checkedMultiplication(int n, int c) {
   // assert: n >= 0 && c > 0
   int o;
   o = n;
 
   while (c > 1) {
 
-    n = safeAddition(n, o);
+    n = checkedAddition(n, o);
 
     if (n == INT_MIN)
       if (c == 2)
@@ -1481,7 +1481,7 @@ int atoi(int* s) {
     next = loadCharacter(s, i);
 
     // multiply by base
-    n = safeMultiplication(n, 10);
+    n = checkedMultiplication(n, 10);
 
     // handle special case, where INT_MIN is allowed
     if (n == INT_MIN)
@@ -1494,7 +1494,7 @@ int atoi(int* s) {
       return -1;
 
     // add least significant digit
-    n = safeAddition(n, c);
+    n = checkedAddition(n, c);
 
     // handle special case, where INT_MIN is allowed
     if (n == INT_MIN)

--- a/selfie.c
+++ b/selfie.c
@@ -106,6 +106,9 @@ int  stringLength(int* s);
 void stringReverse(int* s);
 int  stringCompare(int* s, int* t);
 
+int safeAddition(int n, int c);
+int safeMultiplication(int n, int c);
+
 int  atoi(int* s);
 int* itoa(int n, int* s, int b, int a, int p);
 
@@ -1409,10 +1412,44 @@ int stringCompare(int* s, int* t) {
       return 0;
 }
 
+int safeAddition(int n, int c) {
+  // assert: n > INT_MIN && c >= 0
+
+  if (n <= INT_MAX - c)
+    return n + c;
+  else if (n - 1 == (INT_MAX - c))
+    return INT_MIN;
+  else
+    return -1;
+}
+
+int safeMultiplication(int n, int c) {
+  // assert: n >= 0 && c > 0
+  int o;
+  o = n;
+
+  while (c > 1) {
+
+    n = safeAddition(n, o);
+
+    if (n == INT_MIN)
+      if (c == 2)
+        return INT_MIN;
+    
+    if (n < 0)
+      return -1;
+
+    c = c - 1;
+  }
+
+  return n;
+}
+
 int atoi(int* s) {
   int i;
   int n;
   int c;
+  int next;
 
   // the conversion of the ASCII string in s to its numerical value n
   // begins with the leftmost digit in s
@@ -1437,23 +1474,38 @@ int atoi(int* s) {
       return -1;
 
     // assert: s contains a decimal number, that is, with base 10
-    n = n * 10 + c;
 
     // go to the next digit
     i = i + 1;
 
-    c = loadCharacter(s, i);
+    next = loadCharacter(s, i);
 
-    if (n < 0) {
-      // the only negative number for n allowed here is INT_MIN
-      if (n != INT_MIN)
-        // but n is not INT_MIN which may happen because of an earlier
-        // integer overflow if the number in s is larger than INT_MAX
-        return -1;
-      else if (c != 0)
-        // n is INT_MIN but s is not terminated yet
-        return -1;
-    }
+    // multiply by base
+    n = safeMultiplication(n, 10);
+
+    // handle special case, where INT_MIN is allowed
+    if (n == INT_MIN)
+      if (next == 0)
+        if (c == 0)
+          return INT_MIN;
+  
+    // return -1 on overflow
+    if (n < 0)
+      return -1;
+
+    // add least significant digit
+    n = safeAddition(n, c);
+
+    // handle special case, where INT_MIN is allowed
+    if (n == INT_MIN)
+      if (next == 0)
+        return INT_MIN;
+
+    // return -1 on overflow
+    if (n < 0)
+      return -1;
+
+    c = next;
   }
 
   return n;


### PR DESCRIPTION
This is a possible solution for the issue #16. This issue consists of the problems:
1. Signed integer overflow, which is undefined behavior in C99 (problematic when compiling with gcc/clang, etc...)
2. The logic which should handle big decimal numbers

@julian.kanzler (on slack#cc2017) had a nice idea, to avoid integer multiplication, which is hard to check for an potential overflow. So i could come up with this solution.
All overflow checks rely on the following fact: n + c > INT_MAX   ->   n <= INT_MAX - c   (which is used to check for an possible overflow without the danger of an actual overflow).