### PR TITLE
Added support for compiling under Windows/Visual Studio 2017.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.m
 *.s
+*.obj
 selfie
+selfie.exe

--- a/Makefile.win
+++ b/Makefile.win
@@ -3,7 +3,7 @@ CFLAGS = /O2 /Datoi=xatoi
 
 # Compile selfie.c into selfie executable
 selfie.exe: selfie.c
-	$(CC) $(CFLAGS) selfie.c /Feselfie
+	$(CC) $(CFLAGS) selfie.c /Feselfie.exe
 
 # Consider these targets as targets, not files
 .PHONY : test sat all clean

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,42 @@
+# Compiler flags
+CFLAGS = /O2 /Datoi=xatoi
+
+# Compile selfie.c into selfie executable
+selfie.exe: selfie.c
+	$(CC) $(CFLAGS) selfie.c /Feselfie
+
+# Consider these targets as targets, not files
+.PHONY : test sat all clean
+
+# Test self-compilation, self-execution, and self-hosting
+test: selfie.exe
+	selfie.exe -c selfie.c -o selfie1.m -s selfie1.s -m 2 -c selfie.c -o selfie2.m -s selfie2.s
+	fc selfie1.m selfie2.m
+	fc selfie1.s selfie2.s
+	selfie.exe -c selfie.c -o selfie.m -m 2 -l selfie.m -m 1
+	selfie.exe -c selfie.c -o selfie3.m -s selfie3.s -y 3 -l selfie3.m -y 2 -l selfie3.m -y 2 -c selfie.c -o selfie4.m -s selfie4.s
+	fc selfie3.m selfie4.m
+	fc selfie3.s selfie4.s
+	fc selfie1.m selfie3.m
+	fc selfie1.s selfie3.s
+	selfie.exe -c selfie.c -o selfie5.m -s selfie5.s -min 4 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
+	fc selfie5.m selfie6.m
+	fc selfie5.s selfie6.s
+	fc selfie3.m selfie5.m
+	fc selfie3.s selfie5.s
+	selfie.exe -c -mob 1
+
+# Test SAT solver
+sat: selfie.exe
+	selfie.exe -sat manuscript\cnfs\rivest.cnf
+	selfie.exe -c selfie.c -m 1 -sat manuscript\cnfs\rivest.cnf
+
+# Test everything
+all: test sat
+
+# Clean up
+clean:
+	del *.m
+	del *.obj
+	del *.s
+	del selfie.exe


### PR DESCRIPTION
Added support for compiling under Windows/Visual Studio 2017.

# How to compile

- Prerequisite: Visual Studio 2017 and its C/C++ compiler are installed

- Either start "x64_x86 Cross Tools Command Prompt for VS 2017" or "x86 Native Tools Command Prompt for VS 2017"

- 'cd' into selfie folder

- Type

`> nmake -f Makefile.win TARGETNAME`

to compile TARGETNAME. For compiling selfie.exe type

`> nmake -f Makefile.win selfie.exe`

(only the Makefile target "selfie" was renamed to "selfie.exe"; all other targets kept their existing name).

# For an explanation of Makefile.win:

"diff" was replaced by "fc" (cf. https://stackoverflow.com/q/6877238/497193). Unluckily fc has no "-q" option. Powershell seems to support 'diff', but "x64_x86 Cross Tools Command Prompt for VS 2017" and "x86 Native Tools Command Prompt for VS 2017" currently have no Powershell counterparts. So I considered using "fc" the better solution.

I get no trouble compilation problems when I removed the 'main(a,b)=main(a,char**argv)' definition - so I did remove it.

On the other hand I had to define "atoi" as something different (I chose "xatoi"), since otherwise one gets a name collission with the existing "atoi" function of the C Runtime



# What works and where are still bugs?

`> nmake -f Makefile.win sat`

seems to work.

For the tests in target "test":

`> selfie.exe -c selfie.c -o selfie1.m -s selfie1.s -m 2 -c selfie.c -o selfie2.m -s selfie2.s`

and

`> selfie.exe -c selfie.c -o selfie.m -m 2 -l selfie.m -m 1`

seem to work. On the other hand

`> selfie.exe -c selfie.c -o selfie3.m -s selfie3.s -y 3 -l selfie3.m -y 2 -l selfie3.m -y 2 -c selfie.c -o selfie4.m -s selfie4.s`

outputs:

```
selfie.exe: this is selfie compiling selfie.c with starc
selfie.exe: 191548 characters read in 7576 lines and 1032 comments
selfie.exe: with 105824(55.24%) characters in 31199 actual symbols
selfie.exe: 270 global variables, 311 procedures, 455 string literals
selfie.exe: 2094 calls, 809 assignments, 71 while, 627 if, 287 return
selfie.exe: 129704 bytes generated with 30755 instructions and 6684 bytes of data
selfie.exe: 129704 bytes with 30755 instructions and 6684 bytes of data written into selfie3.m
selfie.exe: 1293223 characters of assembly with 30755 instructions written into selfie3.s
selfie.exe: this is selfie executing selfie3.m with 3MB of physical memory on hypster
selfie3.m: 129704 bytes with 30755 instructions and 6684 bytes of data loaded from selfie3.m
selfie3.m: this is selfie executing selfie3.m with 2MB of physical memory on hypster
selfie.exe: context NULL throws uncaught invalid address
selfie.exe: this is selfie terminating NULL with exit code -8 and 0.52MB of mapped memory
selfie.exe: profile: total,max(ratio%)@addr(line#),2max(ratio%)@addr(line#),3max(ratio%)@addr(line#)
selfie.exe: calls: 427289,64954(15.22%)@0x140B8(~5375),64953(15.22%)@0x22CC(~1134),64920(15.19%)@0x13EE8(~5354)
selfie.exe: loops: 32836,32425(99.00%)@0x1A6D4(~6704),176(0.53%)@0x4F34(~1850),71(0.21%)@0x3B10(~1535)
selfie.exe: loads: 2444977,64954(2.65%)@0x140CC(~5375),64953(2.65%)@0x22E0(~1134),64920(2.65%)@0x13EFC(~5354)
selfie.exe: stores: 1776820,64954(3.65%)@0x140BC(~5375),64953(3.65%)@0x22D0(~1134),64920(3.65%)@0x13EEC(~5354)
```

I take this as a failure. :-(

`> selfie.exe -c selfie.c -o selfie5.m -s selfie5.s -min 4 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s`

again seems to work. Finally for

`> selfie.exe -c -mob 1`

I get the output

```
selfie.exe: nothing to compile, only library generated
selfie.exe: error in library in line 0: procedure main undefined
selfie.exe: 280 bytes generated with 69 instructions and 4 bytes of data
selfie.exe: this is selfie executing library with 1MB of physical memory on mobster
selfie.exe: library exiting with exit code 0 and 0.00MB of mallocated memory
selfie.exe: this is selfie terminating library with exit code 0 and 0.01MB of mapped memory
selfie.exe: profile: total,max(ratio%)@addr(line#),2max(ratio%)@addr(line#),3max(ratio%)@addr(line#)
selfie.exe: calls: 1,1(100.00%)@0x48(~1),0(0.00%),0(0.00%)
selfie.exe: loads: 2,1(50.00%)@0x24(~1),0(0.00%),0(0.00%)
selfie.exe: stores: 1,1(100.00%)@0x4C(~1),0(0.00%),0(0.00%)
```

I don't know whether I should take this as success or failure, since on one hand there is an error message ("selfie.exe: error in library in line 0: procedure main undefined"), but on the other hand this error message also when I compiled and tested selfie under GNU/Linux (Ubuntu).
