### PR TITLE
Increased possible virtual memory size to 4GB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.m
 *.s
 selfie
+selfie.exe

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: selfie
 	diff -q selfie3.s selfie4.s
 	diff -q selfie1.m selfie3.m
 	diff -q selfie1.s selfie3.s
-	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 4 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
+	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 8 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
 	diff -q selfie5.m selfie6.m
 	diff -q selfie5.s selfie6.s
 	diff -q selfie3.m selfie5.m

--- a/selfie.c
+++ b/selfie.c
@@ -6636,7 +6636,9 @@ int pavailable() {
 }
 
 int pused() {
-  int used = usedPageFrameMemory - freePageFrameMemory;
+  int used;
+  
+  used = usedPageFrameMemory - freePageFrameMemory;
 
   if (used < HIGHESTMEMORYADDRESS)
     return used + WORDSIZE;

--- a/selfie.c
+++ b/selfie.c
@@ -7070,7 +7070,7 @@ int mixter(int* toContext, int mix) {
 
 int selfie_run(int machine) {
   int exitCode;
-  
+
   if (binaryLength == 0) {
     print(selfieName);
     print((int*) ": nothing to run, debug, or host");

--- a/selfie.c
+++ b/selfie.c
@@ -4205,10 +4205,10 @@ void emitMainEntry() {
 
   i = 0;
 
-  // 14 NOPs per register is enough for initialization 
-  // since we load positive integers < 2^31 which take 
+  // 15 NOPs per register is enough for initialization 
+  // since we load positive integers < 2^32 which take 
   // no more than 14 instructions each, see load_integer 
-  while (i < 28) { 
+  while (i < 30) { 
     emitRFormat(OP_SPECIAL, 0, 0, 0, FCT_NOP);
 
     i = i + 1;

--- a/selfie.c
+++ b/selfie.c
@@ -2816,11 +2816,17 @@ int load_variable(int* variable) {
 }
 
 void load_integer(int value) {
-  // assert: value >= 0 or value == INT_MIN
+  int isNegative;
 
   talloc();
 
-  if (value >= 0) {
+  if (value != INT_MIN) {
+    if (value < 0) {
+      isNegative = 1;
+      value = -value;
+    } else 
+      isNegative = 0;
+
     if (value < twoToThePowerOf(15))
       // ADDIU can only load numbers < 2^15 without sign extension
       emitIFormat(OP_ADDIU, REG_ZR, currentTemporary(), value);
@@ -2847,6 +2853,10 @@ void load_integer(int value) {
       // and finally add the remaining 3 lsbs
       emitIFormat(OP_ADDIU, currentTemporary(), currentTemporary(), rightShift(leftShift(value, 29), 29));
     }
+
+    if (isNegative)
+      emitRFormat(OP_SPECIAL, REG_ZR, currentTemporary(), currentTemporary(), FCT_SUBU);
+
   } else {
     // load largest positive 16-bit number with a single bit set: 2^14
     emitIFormat(OP_ADDIU, REG_ZR, currentTemporary(), -twoToThePowerOf(14));

--- a/selfie.c
+++ b/selfie.c
@@ -2848,7 +2848,7 @@ void load_integer(int value) {
     }
   } else {
     // load largest positive 16-bit number with a single bit set: 2^14
-    emitIFormat(OP_ADDIU, REG_ZR, currentTemporary(), twoToThePowerOf(14));
+    emitIFormat(OP_ADDIU, REG_ZR, currentTemporary(), -twoToThePowerOf(14));
 
     // and then multiply 2^14 by 2^14*2^3 to get to 2^31 == INT_MIN
     emitLeftShiftBy(currentTemporary(), 14);

--- a/selfie.c
+++ b/selfie.c
@@ -1934,6 +1934,14 @@ int* zalloc(int size) {
 
   memory = malloc(size);
 
+  if ((int) memory == 0) {
+    print(selfieName);
+    print((int*) ": malloc out of physical memory");
+    println();
+
+    exit(EXITCODE_OUTOFPHYSICALMEMORY);
+  }
+
   size = size / WORDSIZE;
 
   i = 0;

--- a/selfie.c
+++ b/selfie.c
@@ -4128,9 +4128,10 @@ void emitMainEntry() {
 
   i = 0;
 
-  // 8 NOPs to initialize the global pointer with a positive integer < 2^28 (see load_integer)
-  // 14 NOPs to initialize the stack pointer with a positive integer < 2^31 (see load_integer)
-  while (i < 22) {
+  // 14 NOPs per register is enough for initialization 
+  // since we load positive integers < 2^31 which take 
+  // no more than 14 instructions each, see load_integer 
+  while (i < 28) { 
     emitRFormat(OP_SPECIAL, 0, 0, 0, FCT_NOP);
 
     i = i + 1;

--- a/selfie.c
+++ b/selfie.c
@@ -4206,8 +4206,8 @@ void emitMainEntry() {
   i = 0;
 
   // 15 NOPs per register is enough for initialization 
-  // since we load positive integers < 2^32 which take 
-  // no more than 14 instructions each, see load_integer 
+  // since we load integers < 2^32 which take 
+  // no more than 15 instructions each, see load_integer 
   while (i < 30) { 
     emitRFormat(OP_SPECIAL, 0, 0, 0, FCT_NOP);
 

--- a/selfie.c
+++ b/selfie.c
@@ -3343,6 +3343,21 @@ int gr_expression() {
     if (ltype != rtype)
       typeWarning(ltype, rtype);
 
+    if (ltype == INTSTAR_T)
+      if (rtype == INTSTAR_T)
+        if (operatorSymbol != SYM_EQUALITY)
+          if (operatorSymbol != SYM_NOTEQ) {
+            // pointer arithmetics: We need to compare pointers as unsigned integers.
+            // We do that, by adding a offset of INT_MIN to get this relationship: 
+            // 0x0 < INT_MAX (0x7FFF FFFF) < INT_MIN (0xFFFF FFFF)
+            load_integer(INT_MIN);
+
+            tfree(1);
+
+            emitRFormat(OP_SPECIAL, previousTemporary(), nextTemporary(), previousTemporary(), FCT_SUBU);
+            emitRFormat(OP_SPECIAL, currentTemporary(), nextTemporary(), currentTemporary(), FCT_SUBU);
+          }
+
     if (operatorSymbol == SYM_EQUALITY) {
       // if a == b load 1 else load 0
       emitIFormat(OP_BEQ, previousTemporary(), currentTemporary(), 4);
@@ -4125,7 +4140,7 @@ void emitLeftShiftBy(int reg, int b) {
 
 void emitRightShiftBy(int reg, int b) {
   // assert: 0 <= b < 31;
-  
+
   int brPositive;
   int brNegative;
 

--- a/selfie.c
+++ b/selfie.c
@@ -7079,9 +7079,8 @@ int selfie_run(int machine) {
   else if (machine == MOBSTER)
     exitCode = mobster(currentContext);
   else if (machine == HYPSTER)
-    if (isValidVirtualAddress((int) malloc(0)))
-      // TODO: does not work if boot level zero actually
-      // does mallocate valid virtual addresses
+    // Detect if selfie's malloc implementation is used
+    if (malloc(0) == malloc(0))
       exitCode = hypster(currentContext);
     else
       // no hypster on boot level zero

--- a/selfie.c
+++ b/selfie.c
@@ -6193,7 +6193,7 @@ void execute() {
   else if (opcode == OP_J)
     op_j();
   else
-      throwException(EXCEPTION_UNKNOWNINSTRUCTION, 0);
+    throwException(EXCEPTION_UNKNOWNINSTRUCTION, 0);
 }
 
 void interrupt() {


### PR DESCRIPTION
Increased possible virtual memory size to 4GB.

## Prerequisites
To be able to allocated ~4GB of Memory, additional compiler flags are needed. On a Windows machine, the linker flag `-Wl,--large-address-aware` (gcc, clang) or `/LARGEADDRESSAWARE` (Visual C++) needs to be added. For Linux and Mac, i haven't tested it yet. I think the Windows Compiler flags won't work on this machines.

## Issues
For 4GB Address space we need unsigned arithmetics. Luckily Selfie has a lot of unsigned MIPS instructions (addu, subu, multu,..). Alltough the overflow detection might detect some overflows, which are in fact legal. For an example if the memory address  `0x7FFF FFFC` is increased by `4` we get `0x8000 0000` and an overflow warning.

Btw.: The instruction selfie DIVU implementation is more of a MIPS DIV instrcution. Signed division wouldn't work with the MIPS DIVU instrution.

## ToDo
We need to detect the operating system in the Makefile and add the corresponding linker flags for the os.
