### PR TITLE
Additions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.m
 *.s
+*.obj
 selfie
+selfie.exe


### PR DESCRIPTION
# Additions to .gitignore that are helpful when working under Git on Windows

The Visual C++ compiler creates *.obj files (which have the same purpose as the *.o files under GNU/Linux). These are ignored. Also added a rule to ignore selfie.exe, too.