### PR TITLE
Increased virtual memory size to 4GB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: selfie
 	diff -q selfie3.s selfie4.s
 	diff -q selfie1.m selfie3.m
 	diff -q selfie1.s selfie3.s
-	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 4 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
+	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 8 -l selfie5.m -y 2 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
 	diff -q selfie5.m selfie6.m
 	diff -q selfie5.s selfie6.s
 	diff -q selfie3.m selfie5.m

--- a/selfie.c
+++ b/selfie.c
@@ -4143,10 +4143,10 @@ void emitMainEntry() {
 
   i = 0;
 
-  // 15 NOPs per register is enough for initialization 
-  // since we load integers -2^31 <= n < 2^31 which take 
+  // 15 NOPs per register is enough for initialization
+  // since we load integers -2^31 <= n < 2^31 which take
   // no more than 15 instructions each, see load_integer
-  while (i < 30) { 
+  while (i < 30) {
     emitRFormat(OP_SPECIAL, 0, 0, 0, FCT_NOP);
 
     i = i + 1;
@@ -6411,7 +6411,7 @@ int* allocateContext(int* parent, int* vctxt, int* in) {
 
   // allocate zeroed memory for page table
   // TODO: save and reuse memory for page table
-  setPT(context, zalloc(NUMBEROFPAGES * WORDSIZE)); 
+  setPT(context, zalloc(NUMBEROFPAGES * WORDSIZE));
 
   // determine range of recently mapped pages
   setLoPage(context, 0);


### PR DESCRIPTION
Increased virtual memory size to 4GB.

## Prerequisites
To be able to allocated ~4GB of Memory, additional compiler flags are needed. On a Windows machine, the linker flag `-Wl,--large-address-aware` (gcc, clang) or `/LARGEADDRESSAWARE` (Visual C++) needs to be added. For Linux and Mac, i haven't tested it yet. I think the Windows Compiler flags won't work on this machines.

## Issues
For 4GB Address space we need unsigned arithmetics. Luckily Selfie has a lot of unsigned MIPS instructions (addu, subu, multu,..). Alltough the overflow detection might detect some overflows, which are in fact legal. For an example if the memory address  `0x7FFF FFFC` is increased by `4` we get `0x8000 0000` and an overflow warning.

Btw.: The instruction selfie DIVU implementation is more of a MIPS DIV instrcution. Signed division wouldn't work with the MIPS DIVU instrution.

## ToDo
We need to detect the operating system in the Makefile and add the corresponding linker flags for the os.
