### PR TITLE
Adapted the semantic of the BEQ instruction from spike

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -4992,7 +4992,7 @@ void fixup_relative_BFormat(uint64_t fromAddress) {
   instruction = loadInstruction(fromAddress);
 
   storeInstruction(fromAddress,
-    encodeBFormat(binaryLength - fromAddress - INSTRUCTIONSIZE,
+    encodeBFormat(binaryLength - fromAddress,
       getRS2(instruction),
       getRS1(instruction),
       getFunct3(instruction),
@@ -6380,11 +6380,11 @@ void record_beq() {
 void do_beq() {
   // branch on equal
 
-  pc = pc + INSTRUCTIONSIZE;
-
   // semantics of beq
   if (*(registers + rs1) == *(registers + rs2))
     pc = pc + imm;
+  else
+    pc = pc + INSTRUCTIONSIZE;
 
   ic_beq = ic_beq + 1;
 }


### PR DESCRIPTION
This should be the right semantic for RISC-V. I recognized this problem as i executed a program (compiled with selfies) with spike.