### PR TITLE
Performance improvement for loading/storing variables

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -2905,7 +2905,7 @@ uint64_t load_variableOrBigInt(uint64_t* variableOrBigInt, uint64_t class) {
   talloc();
 
   if (isSignedInteger(offset, 12)) {
-    emitLD(currentTemporary(), getScope(entry), getAddress(entry));
+    emitLD(currentTemporary(), getScope(entry), offset);
 
     return getType(entry);
   }


### PR DESCRIPTION
I reimplemented the code generation for loading/storing with offsets out of immediate range.
Therefore we used load_integer() with an additional ADD instruction to compute the base address and afterwards LD/SD, which is a total of 4 instructions. 
In my reimplementation we don't use load_integer() anymore but instead we use a single LUI and the additional ADD and LD/SD, which is a total of 3 instructions. The main point is, that we avoid the ADDI instruction from load_integer() and use the immediate part of the LD/SD instruction for that porpuse.
This saves us around thousand instructions for selfie.