### PR TITLE
Encoding error fix, when there are 257+ variables

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -3222,7 +3222,16 @@ void help_procedure_prologue(uint64_t localVariables) {
 
   // allocate memory for callee's local variables
   if (localVariables != 0)
-    emitADDI(REG_SP, REG_SP, -localVariables * REGISTERSIZE);
+    if (isSignedInteger(-localVariables * REGISTERSIZE, 12))
+      emitADDI(REG_SP, REG_SP, -localVariables * REGISTERSIZE);
+    else
+    {
+      load_integer(-localVariables * REGISTERSIZE);
+      
+      emitADD(REG_SP, REG_SP, currentTemporary());
+      
+      tfree(1);
+    }
 }
 
 void help_procedure_epilogue(uint64_t parameters) {

--- a/selfie.c
+++ b/selfie.c
@@ -3221,16 +3221,19 @@ void help_procedure_prologue(uint64_t localVariables) {
   emitADDI(REG_FP, REG_SP, 0);
 
   // allocate memory for callee's local variables
-  if (localVariables != 0)
-    if (isSignedInteger(-localVariables * REGISTERSIZE, 12))
-      emitADDI(REG_SP, REG_SP, -localVariables * REGISTERSIZE);
+  if (localVariables != 0) {
+    localVariables = -localVariables * REGISTERSIZE;
+    
+    if (isSignedInteger(localVariables, 12))
+      emitADDI(REG_SP, REG_SP, localVariables);
     else {
-      load_integer(-localVariables * REGISTERSIZE);
+      load_integer(localVariables);
       
       emitADD(REG_SP, REG_SP, currentTemporary());
       
       tfree(1);
     }
+  }
 }
 
 void help_procedure_epilogue(uint64_t parameters) {

--- a/selfie.c
+++ b/selfie.c
@@ -3224,8 +3224,7 @@ void help_procedure_prologue(uint64_t localVariables) {
   if (localVariables != 0)
     if (isSignedInteger(-localVariables * REGISTERSIZE, 12))
       emitADDI(REG_SP, REG_SP, -localVariables * REGISTERSIZE);
-    else
-    {
+    else {
       load_integer(-localVariables * REGISTERSIZE);
       
       emitADD(REG_SP, REG_SP, currentTemporary());


### PR DESCRIPTION
With 257 local variables, the ADDI uses more than 2^12 bits (signed), which is too much.
We have do a lui and add it in register