### PR TITLE
added global hash table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ selfie: selfie.c
 
 # Self-compile
 compile: selfie
-	./selfie -c selfie.c -o selfie1.m -s selfie1.s -m 2 -c selfie.c -o selfie2.m -s selfie2.s
+	./selfie -c selfie.c -o selfie1.m -s selfie1.s -m 3 -c selfie.c -o selfie2.m -s selfie2.s
 	diff -q selfie1.m selfie2.m
 	diff -q selfie1.s selfie2.s
 
@@ -32,11 +32,11 @@ replay: selfie
 
 # Run emulator on emulator
 os: selfie
-	./selfie -c selfie.c -o selfie.m -m 2 -l selfie.m -m 1
+	./selfie -c selfie.c -o selfie.m -m 3 -l selfie.m -m 1
 
 # Self-compile on two virtual machines
 vm: selfie
-	./selfie -c selfie.c -o selfie3.m -s selfie3.s -m 3 -l selfie3.m -y 3 -l selfie3.m -y 2 -c selfie.c -o selfie4.m -s selfie4.s
+	./selfie -c selfie.c -o selfie3.m -s selfie3.s -m 5 -l selfie3.m -y 5 -l selfie3.m -y 3 -c selfie.c -o selfie4.m -s selfie4.s
 	diff -q selfie3.m selfie4.m
 	diff -q selfie3.s selfie4.s
 	diff -q selfie1.m selfie3.m
@@ -44,7 +44,7 @@ vm: selfie
 
 # Self-compile on two virtual machines on fully mapped virtual memory
 min: selfie
-	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 14 -l selfie5.m -y 3 -l selfie5.m -y 2 -c selfie.c -o selfie6.m -s selfie6.s
+	./selfie -c selfie.c -o selfie5.m -s selfie5.s -min 14 -l selfie5.m -y 5 -l selfie5.m -y 3 -c selfie.c -o selfie6.m -s selfie6.s
 	diff -q selfie5.m selfie6.m
 	diff -q selfie5.s selfie6.s
 	diff -q selfie3.m selfie5.m


### PR DESCRIPTION
Changed the global symbol table to a hash table.

It is a simple fixed size symbol table which saves entries in a linked list at collision.

I think it will speed up the compilation of selfie.
This is expecially useful in the systems and compiler class because you do `make clean test` quite a lot...

I think it speeds up self compilation up to 40% and around 66% of the hast table is filled with entries.