### PR TITLE
Spike: changed memory layout of program args to the UNIX style

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -4519,7 +4519,19 @@ void emitStart() {
   // fixup jump at address 0 to here
   fixup_relative_JFormat(0, binaryLength);
 
-  // calculate the global pointer value accommodating 6 more instructions
+  // prepare main function aguments on the stack
+  talloc();
+
+  // allocate memory for argv variable
+  emitADDI(REG_SP, REG_SP, -REGISTERSIZE);
+
+  // push argv pointer on the stack
+  emitADDI(currentTemporary(), REG_SP, 2 * REGISTERSIZE);
+  emitSD(REG_SP, 0, currentTemporary());
+
+  tfree(1);
+
+  // calculate the global pointer value accommodating 9 more instructions
   gp = ELF_ENTRY_POINT + binaryLength + 6 * INSTRUCTIONSIZE + allocatedMemory;
 
   // make sure gp is double-word-aligned
@@ -8735,36 +8747,55 @@ uint64_t up_loadString(uint64_t* context, uint64_t* s, uint64_t SP) {
 }
 
 void up_loadArguments(uint64_t* context, uint64_t argc, uint64_t* argv) {
+  // uploads arguments in the way of an UNIX system
+  //
+  //    SP
+  //    |
+  //    V
+  // | argc | argv[0] | ... | argv[n] | 0 | env[0] | ... | env[n] | 0 |
+
   uint64_t SP;
-  uint64_t vargv;
-  uint64_t i_argc;
-  uint64_t i_vargv;
+  uint64_t i;
+  uint64_t* vargv;
 
   // the call stack grows top down
   SP = VIRTUALMEMORYSIZE;
 
-  // assert: argc > 0
+  vargv = smalloc(argc * SIZEOFUINT64STAR);
 
-  // allocate memory for storing *argv array
-  SP = SP - argc * REGISTERSIZE;
+  i = 0;
+  // push program parameters to the stack
+  while (i < argc) {
+    SP = up_loadString(context, (uint64_t*) *(argv + i), SP);
 
-  // caution: vargv invalid if argc == 0
-  vargv = SP;
+    // store pointer in virtual *argv
+    *(vargv + i) = SP;
 
-  i_vargv = vargv;
-  i_argc  = argc;
+    i = i + 1;
+  }
 
-  while (i_argc > 0) {
-    SP = up_loadString(context, (uint64_t*) *argv, SP);
+  // allocate memory for env termination
+  SP = SP - REGISTERSIZE;
 
-    // store pointer to string in virtual *argv
-    mapAndStore(context, i_vargv, SP);
+  // push null value to signalize end of env table
+  mapAndStore(context, SP, 0);
 
-    argv = argv + 1;
+  // allocate memory for argv termination
+  SP = SP - REGISTERSIZE;
 
-    i_vargv = i_vargv + REGISTERSIZE;
+  // push null value to signalize end of argv table
+  mapAndStore(context, SP, 0);
 
-    i_argc = i_argc - 1;
+  i = argc;
+  // push pointer table to program parameters to the stack
+  while (i > 0) {
+    // allocate memory for argv table entry
+    SP = SP - REGISTERSIZE;
+
+    i = i - 1;
+
+    // push argv table entry
+    mapAndStore(context, SP, *(vargv + i));
   }
 
   // allocate memory for argc
@@ -8772,12 +8803,6 @@ void up_loadArguments(uint64_t* context, uint64_t argc, uint64_t* argv) {
 
   // push argc
   mapAndStore(context, SP, argc);
-
-  // allocate memory for pointer to virtual argv
-  SP = SP - REGISTERSIZE;
-
-  // push virtual argv
-  mapAndStore(context, SP, vargv);
 
   // store stack pointer value in stack pointer register
   *(getRegs(context) + REG_SP) = SP;

--- a/selfie.c
+++ b/selfie.c
@@ -4519,13 +4519,16 @@ void emitStart() {
   // fixup jump at address 0 to here
   fixup_relative_JFormat(0, binaryLength);
 
-  // prepare main function aguments on the stack
+  // prepare main function arguments on the stack
   talloc();
 
   // allocate memory for argv variable
   emitADDI(REG_SP, REG_SP, -REGISTERSIZE);
 
-  // push argv pointer on the stack
+  // push argv pointer onto the stack
+  //      ______________
+  //     |              V
+  // | &argv | argc | argv[0] | argv[1] | ... | argv[n]
   emitADDI(currentTemporary(), REG_SP, 2 * REGISTERSIZE);
   emitSD(REG_SP, 0, currentTemporary());
 
@@ -8747,7 +8750,7 @@ uint64_t up_loadString(uint64_t* context, uint64_t* s, uint64_t SP) {
 }
 
 void up_loadArguments(uint64_t* context, uint64_t argc, uint64_t* argv) {
-  // uploads arguments in the way of an UNIX system
+  // uploads arguments like a UNIX system
   //
   //    SP
   //    |
@@ -8764,7 +8767,7 @@ void up_loadArguments(uint64_t* context, uint64_t argc, uint64_t* argv) {
   vargv = smalloc(argc * SIZEOFUINT64STAR);
 
   i = 0;
-  // push program parameters to the stack
+  // push program parameters onto the stack
   while (i < argc) {
     SP = up_loadString(context, (uint64_t*) *(argv + i), SP);
 
@@ -8774,20 +8777,20 @@ void up_loadArguments(uint64_t* context, uint64_t argc, uint64_t* argv) {
     i = i + 1;
   }
 
-  // allocate memory for env termination
+  // allocate memory for termination of env table
   SP = SP - REGISTERSIZE;
 
-  // push null value to signalize end of env table
+  // push null value to terminate env table
   mapAndStore(context, SP, 0);
 
-  // allocate memory for argv termination
+  // allocate memory for termination of argv table
   SP = SP - REGISTERSIZE;
 
-  // push null value to signalize end of argv table
+  // push null value to terminate argv table
   mapAndStore(context, SP, 0);
 
   i = argc;
-  // push pointer table to program parameters to the stack
+  // push argv table onto the stack
   while (i > 0) {
     // allocate memory for argv table entry
     SP = SP - REGISTERSIZE;


### PR DESCRIPTION
**Problem**
In order to get Spike working with selfie elf binaries, we need to adapt the memory layout of the Spike emulator on program start. A typical UNIX way of pushing program arguments onto the stack is this:
```
      SP
      |
      V
   | argc | argv[0] | ... | argv[n] | 0 | env[0] | ... | env[n] | 0 |
```

**Solution**
Spike also uses this convention. So in this PR, I updated program argument uploading, when starting a virtual machine or emulator. Also the startup code has to some extra work, to prepare the stack for calling the main function:
```
       SP
       |
       V
   | &argv | argc | argv[0] | ... | argv[n] | 0 | env[0] | ... | env[n] | 0 |
```