### PR TITLE
Simplified docker image creation by importing the riscv tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,85 +1,19 @@
-# builder image
-FROM ubuntu:16.04
+# import image where spike is already installed
+FROM cksystemsteaching/riscv-tools
 
-# specify work directory and RISC-V install directory
-ENV TOP /opt
-ENV RISCV $TOP/riscv
-ENV PATH $PATH:$RISCV/bin
-
-WORKDIR $TOP
-
-# install tools to build RISC-V gnu toolchain, spike and pk
+# install git
 RUN apt-get update && apt-get install -y \
-  autoconf \
-  automake \
-  autotools-dev \
-  curl \
-  device-tree-compiler \
-  libmpc-dev \
-  libmpfr-dev \
-  libgmp-dev \
-  libusb-1.0-0-dev \
-  gawk \
-  build-essential \
-  bison \
-  flex \
-  texinfo \
-  gperf \
-  libtool \
-  patchutils \
-  bc \
-  zlib1g-dev \
-  device-tree-compiler \
-  pkg-config \
-  git \
-  gcc
-
-# get sources from HEAD
-RUN git clone https://github.com/riscv/riscv-tools.git \
-  && cd riscv-tools \
-  && git submodule update --init --recursive
-
-# build everything with gcc
-RUN mkdir -p $RISCV \
-  && cd riscv-tools \
-  && CC=gcc CXX=g++ ./build.sh
-
-# test the RISC-V gnu toolchain
-RUN echo '#include <stdio.h>\n int main(void) { printf("Hello world!\\n"); return 0; }' > hello.c \
-  && riscv64-unknown-elf-gcc -o hello hello.c \
-  && spike pk hello
-
-# remove RISC-V gnu toolchain to shrink image size
- RUN rm -rf \
-    riscv/bin/riscv64-* \
-    riscv/bin/openocd \
-    riscv/lib/gcc \
-    riscv/libexec \
-    riscv/share
-
-# release image
-FROM ubuntu:16.04
-
-# specify work directory and RISC-V install directory
-ENV TOP /opt
-ENV RISCV $TOP/riscv
-ENV PATH $PATH:$RISCV/bin
-
-WORKDIR $TOP
-
-# install gcc, git, make and diff
-RUN apt-get update && apt-get install -y \
-    device-tree-compiler \
-    build-essential \
-    gcc \
     git \
   && rm -rf /var/lib/apt/lists/*
 
-# copy spike and pk from builder image
-COPY --from=0 $RISCV/ $RISCV/
-
-# add selfie to the image
-COPY . $TOP/selfie/
+# add selfie sources to the image
+COPY . /opt/selfie/
 
 # specify user work directory
-WORKDIR $TOP/selfie
+WORKDIR /opt/selfie
+
+# build selfie
+RUN make selfie
+
+# default command
+CMD /bin/bash


### PR DESCRIPTION
***Problem***
The build process for Spike takes hours. But in order to generate selfie docker images automatically (for every commit on the master branch) by e.g. traffis-ci or the docker hub, the build time needs to be very short. 

***Solution***
I extracted all the code to build the RISC-V tools and just imported this image for this container. This results in very fast builds (< 1min) and enables us to include docker into the travis-ci build pipeline. The downside of this is, that we need to build the RISC-V tools image from time to time manually, if we want an up2date version of Spike.