### PR TITLE
Added Spike as new test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ sat: selfie
 	./selfie -sat manuscript/cnfs/rivest.cnf
 	./selfie -c selfie.c -m 1 -sat manuscript/cnfs/rivest.cnf
 
+# Run selfie on Spike
+spike: selfie
+	./selfie -c selfie.c -o selfie.m
+	spike pk selfie.m -l selfie.m -m 2
+
 # Run everything
 all: compile quine debug replay os vm min mob sat
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ selfie: selfie.c
 	$(CC) $(CFLAGS) $< -o $@
 
 # Consider these targets as targets, not files
-.PHONY : compile quine escape debug replay os vm min mob sat all clean
+.PHONY : compile quine escape debug replay os vm min mob sat spike all clean
 
 # Self-compile
 compile: selfie


### PR DESCRIPTION
Selfie should be automatically tested on spike to enforce compatibility with the RISC-V instruction set. This can be done, by specifying a test target, which get's automatically executed by the CI build pipeline.
