### PR TITLE
Integrated Spike into build pipeline with the help of docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ stages:
   - test
   - test on spike
   - name: deploy docker image
-    if: branch = master
+    if: branch = master AND type = push AND fork = false
 jobs:
   include:
     - stage: test on spike

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,28 @@ compiler:
 - clang
 - gcc
 script: travis_wait 60 make all
+stages:
+  - test
+  - test on spike
+  - name: deploy docker image
+    if: branch = master
+jobs:
+  include:
+    - stage: test on spike
+      sudo: required
+      services: docker
+      os: linux
+      script: 
+        - docker build -t cksystemsteaching/selfie .
+        - docker run cksystemsteaching/selfie make spike
+    - stage: deploy docker image
+      sudo: required
+      services: docker
+      os: linux
+      script: 
+        - docker build -t cksystemsteaching/selfie .
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker push cksystemsteaching/selfie
 notifications:
   email: false
   slack:


### PR DESCRIPTION
This PR concludes #79 and #80. This patch results in this build structure:
![screenshot 2018-07-01 at 23 33 46](https://user-images.githubusercontent.com/17096190/42139078-5b7d5628-7d87-11e8-810d-4c950c2e722a.png)

**Test on Spike**
A docker image with the current version of selfie gets built. This image will now be run with the arguments `make spike`, which runs selfie on the Spike emulator. The return value of this gets propagated back to the Travis-CI build pipeline.

**Deploy docker image**
Here the docker image will essentially be deployed to the [docker hub](https://hub.docker.com/). The deployed docker image can now be used by every user by typing `docker run -it cksystemsteaching/selfie`, which starts a new container (simplified vm) with the newest version of selfie, spike and the build utils installed. It starts therefore a complete installation with all the things you need to use selfie. Btw: This build stage will only be executed on the master branch. 
