### PR TITLE
Assembler listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Once you have successfully compiled `selfie.c` you may invoke `selfie` without a
 
 ```bash
 $ ./selfie
-./selfie { -c { source } | -o binary | -s assembly | -l binary | -sat dimacs } [ ( -m | -d | -r | -n | -y | -min | -mob ) 0-64 ... ]
+./selfie { -c { source } | -o binary | -s assembly | -S assembly | -l binary | -sat dimacs } [ ( -m | -d | -r | -n | -y | -min | -mob ) 0-64 ... ]
 ```
 
 In this case, `selfie` responds with its usage pattern.
@@ -74,7 +74,7 @@ The `-o` option writes RISC-U code produced by the most recent compiler invocati
 $ ./selfie -c selfie.c -o selfie.m
 ```
 
-The `-s` option writes RISC-U assembly of the RISC-U code produced by the most recent compiler invocation including approximate source line numbers to the given `assembly` file. Similarly as before, `selfie` may be instructed to compile itself and then output the generated RISC-U code into a RISC-U assembly file called `selfie.s`:
+The `-s` option writes RISC-U assembly of the RISC-U code produced by the most recent compiler invocation to the given `assembly` file. While the `-S` option additionally includes approximate line numbers and the binary representation of the instructions. Similarly as before, `selfie` may be instructed to compile itself and then output the generated RISC-U code into a RISC-U assembly file called `selfie.s`:
 
 ```bash
 $ ./selfie -c selfie.c -s selfie.s

--- a/selfie.c
+++ b/selfie.c
@@ -9961,7 +9961,7 @@ void set_argument(uint64_t* argv) {
 void print_usage() {
   printf3((uint64_t*) "%s: usage: selfie { %s } [ %s ]\n",
     selfie_name,
-      (uint64_t*) "-c { source } | -o binary | -s assembly | -l binary | -sat dimacs",
+      (uint64_t*) "-c { source } | -o binary | -s assembly | -S assembly | -l binary | -sat dimacs",
       (uint64_t*) "( -m | -d | -r | -n | -y | -min | -mob ) 0-64 ...");
 }
 

--- a/selfie.c
+++ b/selfie.c
@@ -1094,6 +1094,8 @@ void do_ecall();
 void undo_ecall();
 void backtrack_ecall();
 
+void print_data(uint64_t data);
+
 // -----------------------------------------------------------------
 // -------------------------- REPLAY ENGINE ------------------------
 // -----------------------------------------------------------------
@@ -7641,6 +7643,10 @@ void backtrack_ecall() {
   efree();
 }
 
+void print_data(uint64_t data) {
+  printf2((uint64_t*) "%x: .quad %x", (uint64_t*) pc, (uint64_t*) data);
+}
+
 // -----------------------------------------------------------------
 // -------------------------- REPLAY ENGINE ------------------------
 // -----------------------------------------------------------------
@@ -8611,6 +8617,8 @@ void print_profile() {
 }
 
 void selfie_disassemble(uint64_t details) {
+  uint64_t data;
+
   assembly_name = get_argument();
 
   if (code_length == 0) {
@@ -8647,6 +8655,15 @@ void selfie_disassemble(uint64_t details) {
     decode_execute();
 
     pc = pc + INSTRUCTIONSIZE;
+  }
+
+  while (pc < binary_length) {
+    data = load_data(pc);
+
+    print_data(data);
+    println();
+
+    pc = pc + REGISTERSIZE;
   }
 
   disassemble_details = 0;


### PR DESCRIPTION
+ Changed the option for the disassembler from `-s` to `-S`
+ Added a new simpler assembly format `-s` (without source line numbers and binary instruction representation)
+ The disassembler now prints the data segment with `-s` and `-S`