### PR TITLE
Native Threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ sat: selfie
 	./selfie -sat manuscript/cnfs/rivest.cnf
 	./selfie -c selfie.c -m 1 -sat manuscript/cnfs/rivest.cnf
 
+# Run test for native threads
+threads: selfie
+	./selfie -c manuscript/code/threads.c -m 2
+	./selfie -c selfie.c -m 4 -c manuscript/code/threads.c -m 2
+
 # Run selfie on spike
 spike: selfie
 	./selfie -c selfie.c -o selfie.m -s selfie.s
@@ -77,7 +82,7 @@ riscv-tools:
 	docker push cksystemsteaching/riscv-tools
 
 # Run everything
-all: compile quine debug replay os vm min mob smt sat
+all: compile quine debug replay os vm min mob smt sat threads
 
 # Clean up
 clean:

--- a/manuscript/code/threads.c
+++ b/manuscript/code/threads.c
@@ -1,0 +1,69 @@
+void initialize();
+void allocate(uint64_t* memory);
+uint64_t check_race_condition();
+
+uint64_t  NUMBER_OF_MALLOCS = 100;
+uint64_t* MEMORY_CHILD;
+uint64_t* MEMORY_PARENT;
+
+void initialize() {
+    MEMORY_CHILD  = malloc(NUMBER_OF_MALLOCS * 8);
+    MEMORY_PARENT = malloc(NUMBER_OF_MALLOCS * 8);
+}
+
+void allocate(uint64_t* memory) {
+    uint64_t i;
+
+    i = 0;
+
+    while (i < NUMBER_OF_MALLOCS) {
+        *(memory + i) = (uint64_t) malloc(8);
+
+        i = i + 1;
+    }
+}
+
+uint64_t check_race_condition() {
+    uint64_t i;
+    uint64_t j;
+    uint64_t rcs;
+
+    i   = 0;
+    rcs = 0;
+
+    while (i < NUMBER_OF_MALLOCS) {
+        j = 0;
+
+        while (j < NUMBER_OF_MALLOCS) {
+            // same address assigned -> race condition occurred
+            if (*(MEMORY_CHILD + i) == *(MEMORY_PARENT + j))
+                rcs = rcs + 1;
+
+            j = j + 1;
+        }
+
+        i = i + 1;
+    }
+
+    return rcs;
+}
+
+uint64_t main() {
+    uint64_t t_id;
+
+    // initialize shared memory buffer
+    initialize();
+
+    t_id = thread();
+
+    if (t_id == 0)
+        allocate(MEMORY_CHILD);
+    else {
+        allocate(MEMORY_PARENT);
+        wait();
+
+        return check_race_condition();
+    }
+
+    return 0;
+}

--- a/selfie.c
+++ b/selfie.c
@@ -277,7 +277,7 @@ uint64_t MAP_SA = 4097;
 
 // mmap shared anonymous mapping
 // LINUX: 49 = 0x0031 = MAP_SHARED (0x0001) | MAP_ANONYMOUS (0x0020) | MAP_FIXED (0x0010)
-// MAC: 4097 = 0x1011 = MAP_SHARED (0x0001) | MAP_ANONYMOUS (0x1000) | MAP_FIXED (0x0010)
+// MAC: 4113 = 0x1011 = MAP_SHARED (0x0001) | MAP_ANONYMOUS (0x1000) | MAP_FIXED (0x0010)
 uint64_t MAP_SAF = 4113;
 
 // ------------------------ GLOBAL VARIABLES -----------------------


### PR DESCRIPTION
This PR is the outcome of the "native" thread implementation developed during the Corey project in SWS. 

## Overview
* Introduced some new system calls (`fork`, `thread`, `wait`, `mmap`, `pid`, `lock`, `unlock`).
* Simple locking mechanism by using `__sync_bool_compare_and_swap()`, an atomic built-in provided by gcc.
* Native fork and wait support for processes.
* Imitating threads by allocating and assigning shared memory with mmap.
* Test file.

## Problems
* We added a new Makefile target, could be that Travis will fail since I am not sure if running more than one process is allowed on their servers.

* Unfortunately, compiling with gcc and all warnings turned on gives a warning. 
This is due to a type conflict of the built-in procedure `fork()`. In our implementation, `fork()` returns the type `uint64_t`, however, `fork()` by default returns an integer (signed) of type `pid_t`. A simple solution would be renaming `fork`.
    ```
    cc -Wall -Wextra -O3 -m64 -D'uint64_t=unsigned long long' selfie.c -o selfie
    selfie.c:117:10: warning: conflicting types for built-in function ‘fork’ [enabled by default]
    uint64_t fork();
            ^
    ```