### PR TITLE
fix selfie not respecting the maximum data segment size properly

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -5412,7 +5412,7 @@ uint64_t load_data(uint64_t baddr) {
 }
 
 void store_data(uint64_t baddr, uint64_t data) {
-  if (baddr >= MAX_CODE_LENGTH + MAX_DATA_LENGTH) {
+  if (baddr - code_length >= MAX_DATA_LENGTH) {
     syntax_error_message("maximum data length exceeded");
 
     exit(EXITCODE_COMPILERERROR);


### PR DESCRIPTION
Currently selfie will compile files with a larger data segment than the allowed maximum (16KB = 16384B) if the code segment hasn't reached its maximum size.
To demonstrate this, one can use this bash script to generate and compile a file with 2048 global variables which will result in a data segment size of 16392B.
```
for i in `seq 1 2048`; do
    echo "uint64_t a_$i = 0;" >> bloat.c
done
echo -e "uint64_t main() {}" >> bloat.c
./selfie -c bloat.c
rm bloat.c
```
A large number of global variables would result in a segfault during the compilation process.

**This is fixed by respecting the actual size of the code segment instead of the upper limit.**