### PR TITLE
Add parameter name to exit() function declaration

### DIFF
--- a/grader/assignments/fork-wait/parallel-print.c
+++ b/grader/assignments/fork-wait/parallel-print.c
@@ -1,5 +1,5 @@
 void* malloc(unsigned long);
-void exit(int);
+void exit(int exit_code);
 uint64_t write(uint64_t fd, uint64_t* buffer, uint64_t bytes_to_write);
 
 uint64_t fork();


### PR DESCRIPTION
While compiling a function declaration, selfie expects a parameter to
have both a type as well as an identifier (by calling compile_variable).

As the exit() function declaration's parameter does not have an
identifier, the compilation of assignment `fork-wait` will emit syntax
errors.