### PR TITLE
Make parents wait for their child within the grader's lock tests

### DIFF
--- a/grader/assignments/lock/print-with-lock.c
+++ b/grader/assignments/lock/print-with-lock.c
@@ -1,12 +1,31 @@
+uint64_t sizeof_uint64 = 8;
+uint64_t number_of_forks = 3;
+
 // global variable for pointing to the "Hello World!    " string
 uint64_t* foo;
 
 // main procedure for printing "Hello World!    " on the console
 int main(int argc, char** argv) {
+  uint64_t pid;
+  uint64_t times_to_wait;
+  uint64_t i;
+  uint64_t* status;
+
+  times_to_wait = 0;
+
   // create 2^3 processes
-  fork();
-  fork();
-  fork();
+  i = 0;
+
+  while (i < number_of_forks) {
+    pid = fork();
+
+    if (pid != 0)
+      times_to_wait = times_to_wait + 1;
+    else
+      times_to_wait = 0;
+
+    i = i + 1;
+  }
 
   // point to the "Hello World!    " string
   foo = "Hello World!    ";
@@ -29,4 +48,14 @@ int main(int argc, char** argv) {
   }
 
   unlock();
+
+  status = malloc(sizeof_uint64);
+
+  i = 0;
+
+  while (i < times_to_wait) {
+    wait(status);
+
+    i = i + 1;
+  }
 }

--- a/grader/assignments/lock/print-without-lock.c
+++ b/grader/assignments/lock/print-without-lock.c
@@ -1,12 +1,31 @@
+uint64_t sizeof_uint64 = 8;
+uint64_t number_of_forks = 3;
+
 // global variable for pointing to the "Hello World!    " string
 uint64_t* foo;
 
 // main procedure for printing "Hello World!    " on the console
 int main(int argc, char** argv) {
+  uint64_t pid;
+  uint64_t times_to_wait;
+  uint64_t i;
+  uint64_t* status;
+
+  times_to_wait = 0;
+
   // create 2^3 processes
-  fork();
-  fork();
-  fork();
+  i = 0;
+
+  while (i < number_of_forks) {
+    pid = fork();
+
+    if (pid != 0)
+      times_to_wait = times_to_wait + 1;
+    else
+      times_to_wait = 0;
+
+    i = i + 1;
+  }
 
   // point to the "Hello World!    " string
   foo = "Hello World!    ";
@@ -24,5 +43,15 @@ int main(int argc, char** argv) {
 
     // go to the next chunk of 8 characters
     foo = foo + 1;
+  }
+
+  status = malloc(sizeof_uint64);
+
+  i = 0;
+
+  while (i < times_to_wait) {
+    wait(status);
+
+    i = i + 1;
   }
 }


### PR DESCRIPTION
If students implemented the `fork-wait` assignment in a way where the entire machine exits as soon as the init-process exits, the outcome of this assignment is dependent on the way they implemented their (probably round-robin) scheduler.
This PR fixes this behaviour by making the parents wait for their children before exiting.