### PR TITLE
Fix race condition in thread assignment

### DIFF
--- a/grader/assignments/thread/syscalls.c
+++ b/grader/assignments/thread/syscalls.c
@@ -16,20 +16,15 @@ uint64_t sumChilds(uint64_t offset, uint64_t pid, uint64_t acc) {
 }
 
 uint64_t get_unique_offset(uint64_t pid1, uint64_t pid2, uint64_t pid3) {
-  uint64_t offset;
+  uint64_t bit0;
+  uint64_t bit1;
+  uint64_t bit2;
 
-  offset = 0;
+  bit0 = pid3 != 0;
+  bit1 = pid2 != 0;
+  bit2 = pid1 != 0;
 
-  if (pid1 != 0)
-    offset = offset + 1;
-  offset = offset * 2;
-  if (pid2 != 0)
-    offset = offset + 1;
-  offset = offset * 2;
-  if (pid3 != 0)
-    offset = offset + 1;
-
-  return offset;
+  return (bit2 * 2 + bit1) * 2 + bit0;
 } 
 
 int main(int argc, char** argv) {

--- a/grader/assignments/thread/syscalls.c
+++ b/grader/assignments/thread/syscalls.c
@@ -4,36 +4,36 @@ uint64_t  pthread_join(uint64_t* wstatus);
 
 uint64_t* status;
 
-uint64_t sumChilds(uint64_t own_pid, uint64_t pid, uint64_t acc) {
+uint64_t sumChilds(uint64_t offset, uint64_t pid, uint64_t acc) {
   if (pid) {
     // this is the parent process/thread
     // => accumulate pid from pthread_create call, pid from pthread_join call and exit status code
-    acc = acc + pid + pthread_join(status + own_pid - 1);
-    acc = acc + *(status + own_pid - 1);
+    acc = acc + pid + pthread_join(status + offset - 1);
+    acc = acc + *(status + offset - 1);
   }
 
   return acc;
 }
 
-uint64_t get_own_pid(uint64_t pid1, uint64_t pid2, uint64_t pid3) {
-  uint64_t pid;
+uint64_t get_unique_offset(uint64_t pid1, uint64_t pid2, uint64_t pid3) {
+  uint64_t offset;
 
-  pid = 0;
+  offset = 0;
 
   if (pid1 != 0)
-    pid = pid + 1;
-  pid = pid * 2;
+    offset = offset + 1;
+  offset = offset * 2;
   if (pid2 != 0)
-    pid = pid + 1;
-  pid = pid * 2;
+    offset = offset + 1;
+  offset = offset * 2;
   if (pid3 != 0)
-    pid = pid + 1;
+    offset = offset + 1;
 
-  return 8 - pid;
+  return 8 - offset;
 } 
 
 int main(int argc, char** argv) {
-  uint64_t own_pid;
+  uint64_t offset;
   uint64_t pid1;
   uint64_t pid2;
   uint64_t pid3;
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
   pid2 = pthread_create();
   pid3 = pthread_create();
 
-  own_pid = get_own_pid(pid1, pid2, pid3);
+  offset = get_unique_offset(pid1, pid2, pid3);
 
   // do not wait for child-threads of the parent-process
   if (pid3 == 0)
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   if (pid2 == 0)
     pid1 = 0;
 
-  result = sumChilds(own_pid, pid3, sumChilds(own_pid, pid2, sumChilds(own_pid, pid1, 0)));
+  result = sumChilds(offset, pid3, sumChilds(offset, pid2, sumChilds(offset, pid1, 0)));
 
   if (pid1 != 0)
     if (pid2 != 0)

--- a/grader/assignments/thread/syscalls.c
+++ b/grader/assignments/thread/syscalls.c
@@ -8,8 +8,8 @@ uint64_t sumChilds(uint64_t offset, uint64_t pid, uint64_t acc) {
   if (pid) {
     // this is the parent process/thread
     // => accumulate pid from pthread_create call, pid from pthread_join call and exit status code
-    acc = acc + pid + pthread_join(status + offset - 1);
-    acc = acc + *(status + offset - 1);
+    acc = acc + pid + pthread_join(status + offset);
+    acc = acc + *(status + offset);
   }
 
   return acc;
@@ -29,7 +29,7 @@ uint64_t get_unique_offset(uint64_t pid1, uint64_t pid2, uint64_t pid3) {
   if (pid3 != 0)
     offset = offset + 1;
 
-  return 8 - offset;
+  return offset;
 } 
 
 int main(int argc, char** argv) {

--- a/grader/assignments/thread/syscalls.c
+++ b/grader/assignments/thread/syscalls.c
@@ -2,31 +2,51 @@ void* malloc(unsigned long);
 uint64_t  pthread_create();
 uint64_t  pthread_join(uint64_t* wstatus);
 
-uint64_t sumChilds(uint64_t pid, uint64_t acc) {
-  uint64_t* s;
+uint64_t* status;
 
-  s = malloc(8);
-
+uint64_t sumChilds(uint64_t own_pid, uint64_t pid, uint64_t acc) {
   if (pid) {
     // this is the parent process/thread
     // => accumulate pid from pthread_create call, pid from pthread_join call and exit status code
-    acc = acc + pid + pthread_join(s);
-    acc = acc + *s;
+    acc = acc + pid + pthread_join(status + own_pid - 1);
+    acc = acc + *(status + own_pid - 1);
   }
 
   return acc;
 }
 
+uint64_t get_own_pid(uint64_t pid1, uint64_t pid2, uint64_t pid3) {
+  uint64_t pid;
+
+  pid = 0;
+
+  if (pid1 != 0)
+    pid = pid + 1;
+  pid = pid * 2;
+  if (pid2 != 0)
+    pid = pid + 1;
+  pid = pid * 2;
+  if (pid3 != 0)
+    pid = pid + 1;
+
+  return 8 - pid;
+} 
+
 int main(int argc, char** argv) {
+  uint64_t own_pid;
   uint64_t pid1;
   uint64_t pid2;
   uint64_t pid3;
   uint64_t result;
 
+  status = malloc(8 * 8);
+
   // 2^3 processes
   pid1 = pthread_create();
   pid2 = pthread_create();
   pid3 = pthread_create();
+
+  own_pid = get_own_pid(pid1, pid2, pid3);
 
   // do not wait for child-threads of the parent-process
   if (pid3 == 0)
@@ -34,7 +54,7 @@ int main(int argc, char** argv) {
   if (pid2 == 0)
     pid1 = 0;
 
-  result = sumChilds(pid3, sumChilds(pid2, sumChilds(pid1, 0)));
+  result = sumChilds(own_pid, pid3, sumChilds(own_pid, pid2, sumChilds(own_pid, pid1, 0)));
 
   if (pid1 != 0)
     if (pid2 != 0)


### PR DESCRIPTION
Our implementation of `malloc` is not thread safe but the assignment assumes it is. `malloc` might return the same address if several threads call it concurrently.

This PR fixes the race condition by using a shared block of memory. Each thread uses its id as an offset to avoid overwriting other thread's data.