### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "c"
+  run = "cc -Wall -Wextra -O3 -m64 -Duint64_t='unsigned long long' selfie.c -o selfie && ./selfie"
+  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Selfie [![Build Status](https://travis-ci.org/cksystemsteaching/selfie.svg?branch=master)](https://travis-ci.org/cksystemsteaching/selfie)
+# Selfie [![Build Status](https://travis-ci.org/cksystemsteaching/selfie.svg?branch=master)](https://travis-ci.org/cksystemsteaching/selfie) [![Run on Repl.it](https://repl.it/badge/github/cksystemsteaching/selfie)](https://repl.it/github/cksystemsteaching/selfie)
 
 Selfie is a project of the [Computational Systems Group](http://www.cs.uni-salzburg.at/~ck) at the Department of Computer Sciences of the University of Salzburg in Austria.
 


### PR DESCRIPTION
Repl.it is an online IDE that's much (much) faster than Cloud9, you also don't need to sign up and the environment comes pre-setup. 

This adds a run on repl.it badge. Your students/users can then just click on that and get started in a matter of seconds. Here is a screenshot of selfie self-compiling

<img width="1373" alt="Screen Shot 2020-02-26 at 3 29 12 PM" src="https://user-images.githubusercontent.com/587518/75397890-f0746300-58ac-11ea-8b2b-f74e7ed1cd8b.png">

If you want to try it before you merge: https://repl.it/@amasad/selfie

