### PR TITLE
Change page-table from a linear table to a tree

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -1072,10 +1072,7 @@ uint64_t NUMBER_OF_LEAF_PTES = 512; // == PAGESIZE / REGISTERSIZE
 
 uint64_t PAGESIZE = 4096; // we use standard 4KB pages
 
-uint64_t PAGE_TABLE_LINEAR = 0; // use a linear page table
 uint64_t PAGE_TABLE_TREE   = 1; // use a two-level tree page table
-
-uint64_t PAGE_TABLE_STRUCTURE = 0; // we use the linear page table
 
 // ------------------------ GLOBAL VARIABLES -----------------------
 
@@ -6770,7 +6767,7 @@ uint64_t leaf_PTE(uint64_t page) {
 uint64_t frame_for_page(uint64_t* parent_table, uint64_t* table, uint64_t page) {
   uint64_t* leaf_pte;
 
-  if (PAGE_TABLE_STRUCTURE == PAGE_TABLE_LINEAR)
+  if (PAGE_TABLE_TREE == 0)
     return (uint64_t) (table + page);
   else {
     leaf_pte = (uint64_t*) load_virtual_memory(parent_table, (uint64_t) (table + root_PTE(page)));
@@ -6785,7 +6782,7 @@ uint64_t frame_for_page(uint64_t* parent_table, uint64_t* table, uint64_t page) 
 uint64_t get_frame_for_page(uint64_t* table, uint64_t page) {
   uint64_t* leaf_pte;
 
-  if (PAGE_TABLE_STRUCTURE == PAGE_TABLE_LINEAR)
+  if (PAGE_TABLE_TREE == 0)
     return *(table + page);
   else {
     leaf_pte = (uint64_t*) *(table + root_PTE(page));
@@ -9160,7 +9157,7 @@ void init_context(uint64_t* context, uint64_t* parent, uint64_t* vctxt) {
 
   // allocate zeroed memory for page table
   // TODO: save and reuse memory for page table
-  if (PAGE_TABLE_STRUCTURE == PAGE_TABLE_LINEAR)
+  if (PAGE_TABLE_TREE == 0)
     set_pt(context, zalloc(VIRTUALMEMORYSIZE / PAGESIZE * REGISTERSIZE));
   else
     set_pt(context, zalloc(VIRTUALMEMORYSIZE / PAGESIZE / NUMBER_OF_LEAF_PTES * REGISTERSIZE));
@@ -9418,7 +9415,7 @@ void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
 
   // assert: 0 <= page < VIRTUALMEMORYSIZE / PAGESIZE
 
-  if (PAGE_TABLE_STRUCTURE == PAGE_TABLE_LINEAR)
+  if (PAGE_TABLE_TREE == 0)
     *(table + page) = frame;
   else {
     root_pte = root_PTE(page);

--- a/selfie.c
+++ b/selfie.c
@@ -6778,10 +6778,7 @@ uint64_t frame_for_page(uint64_t* table, uint64_t* hypervisor_table, uint64_t pa
 
   second_level_index = get_second_level_index_for_page(page);
 
-  if (hypervisor_table != (uint64_t*) 0)
-    leaf_pt = (uint64_t*) load_virtual_memory(hypervisor_table, (uint64_t) (table + first_level_index));
-  else
-    leaf_pt = (uint64_t*) *(table + first_level_index);
+  leaf_pt = (uint64_t*) load_virtual_memory(hypervisor_table, (uint64_t) (table + first_level_index));
 
 
   if (leaf_pt == (uint64_t*) 0)

--- a/selfie.c
+++ b/selfie.c
@@ -6780,13 +6780,10 @@ uint64_t frame_for_page(uint64_t* table, uint64_t page) {
 
   pt_node = (uint64_t*) *(table + first_level_index);
 
-  if (pt_node == (uint64_t*) 0) {
-    pt_node = palloc();
-
-    *(table + first_level_index) = (uint64_t) pt_node;
-  }
-
-  return (uint64_t) (pt_node + second_level_index);
+  if (pt_node == (uint64_t*) 0)
+    return 0;
+  else
+    return (uint64_t) (pt_node + second_level_index);
 }
 
 uint64_t get_frame_for_page(uint64_t* table, uint64_t page) {

--- a/selfie.c
+++ b/selfie.c
@@ -1604,10 +1604,11 @@ void reset_microkernel();
 uint64_t* create_context(uint64_t* parent, uint64_t* vctxt);
 uint64_t* cache_context(uint64_t* vctxt);
 
-void save_context(uint64_t* context);
-void map_page(uint64_t* context, uint64_t page, uint64_t frame);
-void restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi);
-void restore_context(uint64_t* context);
+void      save_context(uint64_t* context);
+void      map_page(uint64_t* context, uint64_t page, uint64_t frame);
+uint64_t* dereference_root_table(uint64_t* parent_table, uint64_t* table);
+void      restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi);
+void      restore_context(uint64_t* context);
 
 // ------------------------ GLOBAL CONSTANTS -----------------------
 
@@ -1621,6 +1622,8 @@ uint64_t* current_context = (uint64_t*) 0; // context currently running
 uint64_t* used_contexts = (uint64_t*) 0; // doubly-linked list of used contexts
 uint64_t* free_contexts = (uint64_t*) 0; // singly-linked list of free contexts
 
+uint64_t* translated_table = (uint64_t*) 0; // root page table translated from vaddr to paddr in hypster
+
 // ------------------------- INITIALIZATION ------------------------
 
 void reset_microkernel() {
@@ -1628,6 +1631,8 @@ void reset_microkernel() {
 
   while (used_contexts != (uint64_t*) 0)
     used_contexts = delete_context(used_contexts, used_contexts);
+
+  translated_table = zalloc(VIRTUALMEMORYSIZE / PAGESIZE / PAGETABLE_NODE_ENTRIES * REGISTERSIZE);
 }
 
 // -----------------------------------------------------------------
@@ -6776,13 +6781,10 @@ uint64_t frame_for_page(uint64_t* table, uint64_t page) {
 
   pt_node = (uint64_t*) *(table + first_level_index);
 
-  if (pt_node == (uint64_t*) 0) {
-    pt_node = palloc();
-
-    *(table + first_level_index) = (uint64_t) pt_node;
-  }
-
-  return (uint64_t) (pt_node + second_level_index);
+  if (pt_node == (uint64_t*) 0)
+    return 0;
+  else
+    return (uint64_t) (pt_node + second_level_index);
 }
 
 uint64_t get_frame_for_page(uint64_t* table, uint64_t page) {
@@ -9454,15 +9456,36 @@ void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
   }
 }
 
+uint64_t* dereference_root_table(uint64_t* parent_table, uint64_t* table) {
+  uint64_t i;
+
+  i = 0;
+
+  while (i < VIRTUALMEMORYSIZE / PAGESIZE / PAGETABLE_NODE_ENTRIES) {
+    // Check whether the root table entry is mapped.
+    // The root table node is allocated using zalloc and may span over multiple pages
+    // that might not be mapped due to lazy mapping.
+    if (is_virtual_address_mapped(parent_table, (uint64_t) (table + i)))
+      *(translated_table + i) = (uint64_t) tlb(parent_table, load_virtual_memory(parent_table, (uint64_t) (table + i)));
+    else
+      *(translated_table + i) = 0;
+
+    i = i + 1;
+  }
+
+  return translated_table;
+}
+
 void restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi) {
   uint64_t frame;
+  uint64_t* deref_table;
+
+  deref_table = dereference_root_table(parent_table, table);
 
   while (lo <= hi) {
-    if (is_virtual_address_mapped(parent_table, frame_for_page(table, lo))) {
-      frame = load_virtual_memory(parent_table, frame_for_page(table, lo));
+    frame = load_physical_memory((uint64_t*) frame_for_page(deref_table, lo));
 
-      map_page(context, lo, get_frame_for_page(parent_table, get_page_of_virtual_address(frame)));
-    }
+    map_page(context, lo, get_frame_for_page(parent_table, get_page_of_virtual_address(frame)));
 
     lo = lo + 1;
   }

--- a/selfie.c
+++ b/selfie.c
@@ -1038,10 +1038,10 @@ void init_memory(uint64_t megabytes);
 uint64_t load_physical_memory(uint64_t* paddr);
 void     store_physical_memory(uint64_t* paddr, uint64_t data);
 
-uint64_t root_page_table_index_for_page(uint64_t page);
-uint64_t leaf_page_table_index_for_page(uint64_t page);
+uint64_t root_PTE(uint64_t page);
+uint64_t leaf_PTE(uint64_t page);
 
-uint64_t frame_for_page(uint64_t* table, uint64_t* hypervisor_table, uint64_t page);
+uint64_t frame_for_page(uint64_t* parent_table, uint64_t* table, uint64_t page);
 uint64_t get_frame_for_page(uint64_t* table, uint64_t page);
 uint64_t is_page_mapped(uint64_t* table, uint64_t page);
 
@@ -1068,7 +1068,7 @@ uint64_t WORDSIZEINBITS = 32;
 uint64_t INSTRUCTIONSIZE = 4; // must be the same as WORDSIZE
 uint64_t REGISTERSIZE    = 8; // must be twice of WORDSIZE
 
-uint64_t LEAF_PAGE_TABLE_ENTRIES = 512; // i.e. one leaf page table has the size PAGESIZE
+uint64_t NUMBER_OF_LEAF_PTES = 512; // == PAGESIZE / REGISTERSIZE
 
 uint64_t PAGESIZE = 4096; // we use standard 4KB pages
 
@@ -6754,35 +6754,35 @@ void store_physical_memory(uint64_t* paddr, uint64_t data) {
   *paddr = data;
 }
 
-uint64_t root_page_table_index_for_page(uint64_t page) {
-  return (page / LEAF_PAGE_TABLE_ENTRIES);
+uint64_t root_PTE(uint64_t page) {
+  return (page / NUMBER_OF_LEAF_PTES);
 }
 
-uint64_t leaf_page_table_index_for_page(uint64_t page) {
-  return (page - root_page_table_index_for_page(page) * LEAF_PAGE_TABLE_ENTRIES);
+uint64_t leaf_PTE(uint64_t page) {
+  return (page - root_PTE(page) * NUMBER_OF_LEAF_PTES);
 }
 
-uint64_t frame_for_page(uint64_t* table, uint64_t* hypervisor_table, uint64_t page) {
-  uint64_t* leaf_pt;
+uint64_t frame_for_page(uint64_t* parent_table, uint64_t* table, uint64_t page) {
+  uint64_t* leaf_pte;
 
-  leaf_pt = (uint64_t*) load_virtual_memory(hypervisor_table, (uint64_t) (table + root_page_table_index_for_page(page)));
+  leaf_pte = (uint64_t*) load_virtual_memory(parent_table, (uint64_t) (table + root_PTE(page)));
 
-  if (leaf_pt == (uint64_t*) 0)
+  if (leaf_pte == (uint64_t*) 0)
     return 0;
   else
-    return (uint64_t) (leaf_pt + leaf_page_table_index_for_page(page));
+    return (uint64_t) (leaf_pte + leaf_PTE(page));
 }
 
 uint64_t get_frame_for_page(uint64_t* table, uint64_t page) {
-  uint64_t* leaf_pt;
+  uint64_t* leaf_pte;
 
-  leaf_pt = (uint64_t*) *(table + root_page_table_index_for_page(page));
+  leaf_pte = (uint64_t*) *(table + root_PTE(page));
 
-  if (leaf_pt == (uint64_t*) 0)
-    // page isn't mapped if the corresponding internal node isn't mapped
+  if (leaf_pte == (uint64_t*) 0)
+    // page is unmapped if leaf PTE is unmapped
     return 0;
   else
-    return *(leaf_pt + leaf_page_table_index_for_page(page));
+    return *(leaf_pte + leaf_PTE(page));
 }
 
 uint64_t is_page_mapped(uint64_t* table, uint64_t page) {
@@ -9147,7 +9147,7 @@ void init_context(uint64_t* context, uint64_t* parent, uint64_t* vctxt) {
 
   // allocate zeroed memory for page table
   // TODO: save and reuse memory for page table
-  set_pt(context, zalloc(VIRTUALMEMORYSIZE / PAGESIZE / LEAF_PAGE_TABLE_ENTRIES * REGISTERSIZE));
+  set_pt(context, zalloc(VIRTUALMEMORYSIZE / PAGESIZE / NUMBER_OF_LEAF_PTES * REGISTERSIZE));
 
   // determine range of recently mapped pages
   set_lowest_lo_page(context, 0);
@@ -9394,24 +9394,24 @@ void save_context(uint64_t* context) {
 
 void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
   uint64_t* table;
-  uint64_t* leaf_pt;
-  uint64_t  root_pt_index;
+  uint64_t* leaf_pte;
+  uint64_t  root_pte;
 
   table = get_pt(context);
 
   // assert: 0 <= page < VIRTUALMEMORYSIZE / PAGESIZE
 
-  root_pt_index = root_page_table_index_for_page(page);
+  root_pte = root_PTE(page);
 
-  leaf_pt = (uint64_t*) *(table + root_pt_index);
+  leaf_pte = (uint64_t*) *(table + root_pte);
 
-  if (leaf_pt == (uint64_t*) 0) {
-    leaf_pt = palloc();
+  if (leaf_pte == (uint64_t*) 0) {
+    leaf_pte = palloc();
 
-    *(table + root_pt_index) = (uint64_t) leaf_pt;
+    *(table + root_pte) = (uint64_t) leaf_pte;
   }
 
-  *(leaf_pt + leaf_page_table_index_for_page(page)) = frame;
+  *(leaf_pte + leaf_PTE(page)) = frame;
 
   // exploit spatial locality in page table caching
   if (page <= get_page_of_virtual_address(get_program_break(context) - REGISTERSIZE)) {
@@ -9437,8 +9437,8 @@ void restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, 
   uint64_t frame;
 
   while (lo <= hi) {
-    if (is_virtual_address_mapped(parent_table, frame_for_page(table, parent_table, lo))) {
-      frame = load_virtual_memory(parent_table, frame_for_page(table, parent_table, lo));
+    if (is_virtual_address_mapped(parent_table, frame_for_page(parent_table, table, lo))) {
+      frame = load_virtual_memory(parent_table, frame_for_page(parent_table, table, lo));
 
       map_page(context, lo, get_frame_for_page(parent_table, get_page_of_virtual_address(frame)));
     }

--- a/selfie.c
+++ b/selfie.c
@@ -6762,12 +6762,16 @@ void store_physical_memory(uint64_t* paddr, uint64_t data) {
 uint64_t get_first_level_index_for_page(uint64_t page) {
   // The 9 least significant bits contain the second level index.
   // The first level index comes afterwards.
-  return right_shift(page, 9);
+  // The shift functions aren't used since they are too slow for
+  // this frequently called function.
+  return (page / 512);
 }
 
 uint64_t get_second_level_index_for_page(uint64_t page) {
-  // retrieve lowest 9 bits
-  return right_shift(left_shift(page, 55), 55);
+  // retrieve lowest 9 bits (left shift by 55 and right shift by 55)
+  // The shift functions aren't used since they are too slow for
+  // this frequently called function.
+  return ((page * 36028797018963970) / 36028797018963970);
 }
 
 uint64_t frame_for_page(uint64_t* table, uint64_t page) {

--- a/selfie.c
+++ b/selfie.c
@@ -9411,12 +9411,12 @@ void save_context(uint64_t* context) {
 }
 
 void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
-  uint64_t* table_root;
+  uint64_t* table;
   uint64_t* pt_node;
   uint64_t  first_level_index;
   uint64_t  second_level_index;
 
-  table_root = get_pt(context);
+  table = get_pt(context);
 
   // assert: 0 <= page < VIRTUALMEMORYSIZE / PAGESIZE
 
@@ -9424,12 +9424,12 @@ void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
 
   second_level_index = get_second_level_index_for_page(page);
 
-  pt_node = (uint64_t*) *(table_root + first_level_index);
+  pt_node = (uint64_t*) *(table + first_level_index);
 
   if (pt_node == (uint64_t*) 0) {
     pt_node = palloc();
 
-    *(table_root + first_level_index) = (uint64_t) pt_node;
+    *(table + first_level_index) = (uint64_t) pt_node;
   }
 
   *(pt_node + second_level_index) = frame;

--- a/selfie.c
+++ b/selfie.c
@@ -1501,27 +1501,26 @@ uint64_t* delete_context(uint64_t* context, uint64_t* from);
 // | 13 | exit code       | exit code
 // | 14 | parent          | context that created this context
 // | 15 | virtual context | virtual context address
-// | 16 | vctxt cached pt | dereferenced page table root note of the virtual context
-// | 17 | name            | binary name loaded into context
+// | 16 | name            | binary name loaded into context
 // +----+-----------------+
 // symbolic extension:
 // +----+-----------------+
-// | 18 | execution depth | number of executed instructions
-// | 19 | path condition  | pointer to path condition
-// | 20 | symbolic memory | pointer to symbolic memory
-// | 21 | symbolic regs   | pointer to symbolic registers
-// | 22 | beq counter     | number of executed symbolic beq instructions
-// | 23 | merge location  | program location at which the context can possibly be merged (later)
-// | 24 | merge partner   | pointer to the context from which this context was created
-// | 25 | call stack      | pointer to a list containing the addresses of the procedures on the call stack
+// | 17 | execution depth | number of executed instructions
+// | 18 | path condition  | pointer to path condition
+// | 19 | symbolic memory | pointer to symbolic memory
+// | 20 | symbolic regs   | pointer to symbolic registers
+// | 21 | beq counter     | number of executed symbolic beq instructions
+// | 22 | merge location  | program location at which the context can possibly be merged (later)
+// | 23 | merge partner   | pointer to the context from which this context was created
+// | 24 | call stack      | pointer to a list containing the addresses of the procedures on the call stack
 // +----+-----------------+
 
 uint64_t* allocate_context() {
-  return smalloc(8 * SIZEOFUINT64STAR + 10 * SIZEOFUINT64);
+  return smalloc(7 * SIZEOFUINT64STAR + 10 * SIZEOFUINT64);
 }
 
 uint64_t* allocate_symbolic_context() {
-  return smalloc(8 * SIZEOFUINT64STAR + 10 * SIZEOFUINT64 + 5 * SIZEOFUINT64STAR + 3 * SIZEOFUINT64);
+  return smalloc(7 * SIZEOFUINT64STAR + 10 * SIZEOFUINT64 + 5 * SIZEOFUINT64STAR + 3 * SIZEOFUINT64);
 }
 
 uint64_t next_context(uint64_t* context)    { return (uint64_t) context; }
@@ -1540,8 +1539,7 @@ uint64_t faulting_page(uint64_t* context)   { return (uint64_t) (context + 12); 
 uint64_t exit_code(uint64_t* context)       { return (uint64_t) (context + 13); }
 uint64_t parent(uint64_t* context)          { return (uint64_t) (context + 14); }
 uint64_t virtual_context(uint64_t* context) { return (uint64_t) (context + 15); }
-uint64_t vctxt_cached_pt(uint64_t* context) { return (uint64_t) (context + 16); }
-uint64_t name(uint64_t* context)            { return (uint64_t) (context + 17); }
+uint64_t name(uint64_t* context)            { return (uint64_t) (context + 16); }
 
 uint64_t* get_next_context(uint64_t* context)    { return (uint64_t*) *context; }
 uint64_t* get_prev_context(uint64_t* context)    { return (uint64_t*) *(context + 1); }
@@ -1559,17 +1557,16 @@ uint64_t  get_faulting_page(uint64_t* context)   { return             *(context 
 uint64_t  get_exit_code(uint64_t* context)       { return             *(context + 13); }
 uint64_t* get_parent(uint64_t* context)          { return (uint64_t*) *(context + 14); }
 uint64_t* get_virtual_context(uint64_t* context) { return (uint64_t*) *(context + 15); }
-uint64_t* get_vctxt_cached_pt(uint64_t* context) { return (uint64_t*) *(context + 16); }
-char*     get_name(uint64_t* context)            { return (char*)     *(context + 17); }
+char*     get_name(uint64_t* context)            { return (char*)     *(context + 16); }
 
-uint64_t  get_execution_depth(uint64_t* context) { return             *(context + 18); }
-char*     get_path_condition(uint64_t* context)  { return (char*)     *(context + 19); }
-uint64_t* get_symbolic_memory(uint64_t* context) { return (uint64_t*) *(context + 20); }
-uint64_t* get_symbolic_regs(uint64_t* context)   { return (uint64_t*) *(context + 21); }
-uint64_t  get_beq_counter(uint64_t* context)     { return             *(context + 22); }
-uint64_t  get_merge_location(uint64_t* context)  { return             *(context + 23); }
-uint64_t* get_merge_partner(uint64_t* context)   { return (uint64_t*) *(context + 24); }
-uint64_t* get_call_stack(uint64_t* context)      { return (uint64_t*) *(context + 25); }
+uint64_t  get_execution_depth(uint64_t* context) { return             *(context + 17); }
+char*     get_path_condition(uint64_t* context)  { return (char*)     *(context + 18); }
+uint64_t* get_symbolic_memory(uint64_t* context) { return (uint64_t*) *(context + 19); }
+uint64_t* get_symbolic_regs(uint64_t* context)   { return (uint64_t*) *(context + 20); }
+uint64_t  get_beq_counter(uint64_t* context)     { return             *(context + 21); }
+uint64_t  get_merge_location(uint64_t* context)  { return             *(context + 22); }
+uint64_t* get_merge_partner(uint64_t* context)   { return (uint64_t*) *(context + 23); }
+uint64_t* get_call_stack(uint64_t* context)      { return (uint64_t*) *(context + 24); }
 
 void set_next_context(uint64_t* context, uint64_t* next)      { *context        = (uint64_t) next; }
 void set_prev_context(uint64_t* context, uint64_t* prev)      { *(context + 1)  = (uint64_t) prev; }
@@ -1587,17 +1584,16 @@ void set_faulting_page(uint64_t* context, uint64_t page)      { *(context + 12) 
 void set_exit_code(uint64_t* context, uint64_t code)          { *(context + 13) = code; }
 void set_parent(uint64_t* context, uint64_t* parent)          { *(context + 14) = (uint64_t) parent; }
 void set_virtual_context(uint64_t* context, uint64_t* vctxt)  { *(context + 15) = (uint64_t) vctxt; }
-void set_vctxt_cached_pt(uint64_t* context, uint64_t* vctxt)  { *(context + 16) = (uint64_t) vctxt; }
-void set_name(uint64_t* context, char* name)                  { *(context + 17) = (uint64_t) name; }
+void set_name(uint64_t* context, char* name)                  { *(context + 16) = (uint64_t) name; }
 
-void set_execution_depth(uint64_t* context, uint64_t depth)    { *(context + 18) =            depth; }
-void set_path_condition(uint64_t* context, char* path)         { *(context + 19) = (uint64_t) path; }
-void set_symbolic_memory(uint64_t* context, uint64_t* memory)  { *(context + 20) = (uint64_t) memory; }
-void set_symbolic_regs(uint64_t* context, uint64_t* regs)      { *(context + 21) = (uint64_t) regs; }
-void set_beq_counter(uint64_t* context, uint64_t counter)      { *(context + 22) =            counter; }
-void set_merge_location(uint64_t* context, uint64_t location)  { *(context + 23) =            location; }
-void set_merge_partner(uint64_t* context, uint64_t* partner)   { *(context + 24) = (uint64_t) partner; }
-void set_call_stack(uint64_t* context, uint64_t* stack)        { *(context + 25) = (uint64_t) stack; }
+void set_execution_depth(uint64_t* context, uint64_t depth)    { *(context + 17) =            depth; }
+void set_path_condition(uint64_t* context, char* path)         { *(context + 18) = (uint64_t) path; }
+void set_symbolic_memory(uint64_t* context, uint64_t* memory)  { *(context + 19) = (uint64_t) memory; }
+void set_symbolic_regs(uint64_t* context, uint64_t* regs)      { *(context + 20) = (uint64_t) regs; }
+void set_beq_counter(uint64_t* context, uint64_t counter)      { *(context + 21) =            counter; }
+void set_merge_location(uint64_t* context, uint64_t location)  { *(context + 22) =            location; }
+void set_merge_partner(uint64_t* context, uint64_t* partner)   { *(context + 23) = (uint64_t) partner; }
+void set_call_stack(uint64_t* context, uint64_t* stack)        { *(context + 24) = (uint64_t) stack; }
 
 // -----------------------------------------------------------------
 // -------------------------- MICROKERNEL --------------------------
@@ -1608,11 +1604,11 @@ void reset_microkernel();
 uint64_t* create_context(uint64_t* parent, uint64_t* vctxt);
 uint64_t* cache_context(uint64_t* vctxt);
 
-void save_context(uint64_t* context);
-void map_page(uint64_t* context, uint64_t page, uint64_t frame);
-void dereference_root_table(uint64_t* parent_table, uint64_t* table, uint64_t* cached_root);
-void restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi);
-void restore_context(uint64_t* context);
+void      save_context(uint64_t* context);
+void      map_page(uint64_t* context, uint64_t page, uint64_t frame);
+uint64_t* dereference_root_table(uint64_t* parent_table, uint64_t* table);
+void      restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi);
+void      restore_context(uint64_t* context);
 
 // ------------------------ GLOBAL CONSTANTS -----------------------
 
@@ -1626,6 +1622,8 @@ uint64_t* current_context = (uint64_t*) 0; // context currently running
 uint64_t* used_contexts = (uint64_t*) 0; // doubly-linked list of used contexts
 uint64_t* free_contexts = (uint64_t*) 0; // singly-linked list of free contexts
 
+uint64_t* translated_table = (uint64_t*) 0; // root page table translated from vaddr to paddr in hypster
+
 // ------------------------- INITIALIZATION ------------------------
 
 void reset_microkernel() {
@@ -1633,6 +1631,8 @@ void reset_microkernel() {
 
   while (used_contexts != (uint64_t*) 0)
     used_contexts = delete_context(used_contexts, used_contexts);
+
+  translated_table = zalloc(VIRTUALMEMORYSIZE / PAGESIZE / PAGETABLE_NODE_ENTRIES * REGISTERSIZE);
 }
 
 // -----------------------------------------------------------------
@@ -9187,10 +9187,6 @@ void init_context(uint64_t* context, uint64_t* parent, uint64_t* vctxt) {
   set_parent(context, parent);
   set_virtual_context(context, vctxt);
 
-  // allocate zeroed memory for the cached virtual context root node
-  // TODO: reuse memory
-  set_vctxt_cached_pt(context, zalloc(VIRTUALMEMORYSIZE / PAGESIZE / PAGETABLE_NODE_ENTRIES * REGISTERSIZE));
-
   set_name(context, 0);
 
   if (symbolic) {
@@ -9264,7 +9260,6 @@ uint64_t* copy_context(uint64_t* original, uint64_t location, char* condition) {
   set_exit_code(context, get_exit_code(original));
   set_parent(context, get_parent(original));
   set_virtual_context(context, get_virtual_context(original));
-  set_vctxt_cached_pt(context, get_vctxt_cached_pt(original));
   set_name(context, get_name(original));
 
   set_execution_depth(context, get_execution_depth(original));
@@ -9465,7 +9460,7 @@ void map_page(uint64_t* context, uint64_t page, uint64_t frame) {
   }
 }
 
-void dereference_root_table(uint64_t* parent_table, uint64_t* table, uint64_t* cached_root) {
+uint64_t* dereference_root_table(uint64_t* parent_table, uint64_t* table) {
   uint64_t i;
 
   i = 0;
@@ -9475,25 +9470,21 @@ void dereference_root_table(uint64_t* parent_table, uint64_t* table, uint64_t* c
     // The root table node is allocated using zalloc and may span over multiple pages
     // that might not be mapped due to lazy mapping.
     if (is_virtual_address_mapped(parent_table, (uint64_t) (table + i)))
-      *(cached_root + i) = (uint64_t) tlb(parent_table, load_virtual_memory(parent_table, (uint64_t) (table + i)));
+      *(translated_table + i) = (uint64_t) tlb(parent_table, load_virtual_memory(parent_table, (uint64_t) (table + i)));
     else
-      *(cached_root + i) = 0;
+      *(translated_table + i) = 0;
 
     i = i + 1;
   }
+
+  return translated_table;
 }
 
 void restore_region(uint64_t* context, uint64_t* table, uint64_t* parent_table, uint64_t lo, uint64_t hi) {
   uint64_t frame;
   uint64_t* deref_table;
 
-  deref_table = get_vctxt_cached_pt(context);
-
-  // Only dereference pointers to leaf nodes if new pages have been mapped in the vctxt.
-  if (is_page_mapped(get_pt(context), hi) == 0)
-    dereference_root_table(parent_table, table, deref_table);
-  else if (is_page_mapped(get_pt(context), lo) == 0)
-    dereference_root_table(parent_table, table, deref_table);
+  deref_table = dereference_root_table(parent_table, table);
 
   while (lo <= hi) {
     frame = load_physical_memory((uint64_t*) frame_for_page(deref_table, lo));


### PR DESCRIPTION
@Blazefrost and I changed the page-table to use a tree instead of a linear table. This reduces memory consumption in basically every case drastically.