### PR TITLE
Fix behavior of open_write_only on Windows

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -5896,17 +5896,16 @@ uint64_t open_write_only(char* name) {
   // not always work and require intervention
   uint64_t fd;
 
-  // try Mac flags
-  // add Windows _O_BINARY flag (32768 = 0x8000) as a hack to make sure existing files are opened properly on Windows
-  fd = sign_extend(open(name, MAC_O_CREAT_TRUNC_WRONLY + 32768, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
+  // try Windows flags
+  fd = sign_extend(open(name, WINDOWS_O_BINARY_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
 
   if (signed_less_than(fd, 0)) {
-    // try Linux flags
-    fd = sign_extend(open(name, LINUX_O_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
+    // try Mac flags
+    fd = sign_extend(open(name, MAC_O_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
 
     if (signed_less_than(fd, 0))
-      // try Windows flags
-      fd = sign_extend(open(name, WINDOWS_O_BINARY_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
+      // try Linux flags
+      fd = sign_extend(open(name, LINUX_O_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
   }
 
   return fd;

--- a/selfie.c
+++ b/selfie.c
@@ -5897,7 +5897,8 @@ uint64_t open_write_only(char* name) {
   uint64_t fd;
 
   // try Mac flags
-  fd = sign_extend(open(name, MAC_O_CREAT_TRUNC_WRONLY, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
+  // add Windows _O_BINARY flag (32768 = 0x8000) as a hack to make sure existing files are opened properly on Windows
+  fd = sign_extend(open(name, MAC_O_CREAT_TRUNC_WRONLY + 32768, S_IRUSR_IWUSR_IRGRP_IROTH), SYSCALL_BITWIDTH);
 
   if (signed_less_than(fd, 0)) {
     // try Linux flags


### PR DESCRIPTION
When `open_write_only` is used to open an existing file on Windows, the Mac call goes through, which results in the file not being opened in binary mode. This can be fixed by adding the `_O_BINARY` flag from Windows to the Mac call, while hopefully not breaking anything on Mac.