### PR TITLE
fix bug in multi-line comments

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -2626,6 +2626,13 @@ uint64_t find_next_character() {
 
         get_character();
 
+        while (character == CHAR_ASTERISK) {
+          // loop over consecutive asterisks to check for "*/"
+          number_of_ignored_characters = number_of_ignored_characters + 1;
+
+          get_character();
+        }
+
         if (character == CHAR_SLASH) {
           // multi-line comments end with "*/"
           in_multi_line_comment = 0;


### PR DESCRIPTION
When terminating a multi-line comment with an even number of asterisks we ignore the last asterisk before the terminating "/" and get an error message for "runaway multi-line comment". We need to do a lookahead of one, afer an asterisk to find the end, but then ignore the following character. Therefore the simplest solution providing easiest readability seems to be looping over all asterisks.