### PR TITLE
Fix Docker build failing

### DIFF
--- a/Dockerselfie
+++ b/Dockerselfie
@@ -199,6 +199,9 @@ RUN apt-get update \
        libc-dev-riscv64-cross \
        make \
        device-tree-compiler \
+       xxd \
+       gettext \
+       curl \
        clang \
        lld \
        llvm \


### PR DESCRIPTION
Unfortunately three dependencies for building the machine setup weren't installed in the Dockerfile. This has been fixed with 0c7109b.