### PR TITLE
Fix compiler warnings when compiling with GCC 10.2.0 (fixes #216)

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -5221,6 +5221,8 @@ void selfie_compile() {
   uint64_t number_of_source_files;
   uint64_t fetch_dss_code_location;
 
+  fetch_dss_code_location = 0;
+
   // link until next console option
   link = 1;
 

--- a/selfie.c
+++ b/selfie.c
@@ -7720,7 +7720,9 @@ void print_gc_profile(uint64_t* context) {
     (char*) fixed_point_ratio(gc_mem_metadata, MEGABYTE, 2),
     (char*) fixed_point_percentage(fixed_point_ratio(gc_mem_mallocated, gc_mem_metadata, 4), 4),
     (char*) gc_num_ungced_mallocs);
-  if (is_gc_library(context) == 0) print(" (external)"); println();
+  if (is_gc_library(context) == 0)
+    print(" (external)");
+  println();
 }
 
 void gc_arguments() {


### PR DESCRIPTION
The `-Wmaybe-uninitialized` is really strange in my opinion. It only occurs when optimization is activated, which is also mentioned on the gcc manpage. There, it also says that sometimes these warnings can happen because the compiler could not verify a code snippet's correctness. What I don't really understand is why the compiler does not see that both branch conditions in `selfie_compile()` depend on `GC_ON` which is never modfied between both of them.

The fix (commit 49db4c9) is a little bit ugly in my opinion but I did not find a better solution. An alternative would be to pass `-Wno-maybe-uninitialized` as a C-flag but I guess this would do more harm than good.