### PR TITLE
Grader: Use argparse library for argument parsing (fixes #146 and #141)

### DIFF
--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -16,6 +16,22 @@ from lib.print import (is_in_quiet_mode, enter_quiet_mode, leave_quiet_mode, pri
                        stop_processing_spinner, print_passed, print_failed)
 
 DEFAULT_BULK_GRADE_DIRECTORY = os.path.abspath('./.repositories')
+GRADER_SYNOPSIS = '''
+The Selfie autograder
+
+The autograder is a tool that gives students and teachers the means
+for evaluating assignments that shall extend or adapt Selfie with
+concepts learned in the lecture.
+It also enables teachers to fetch and grade multiple Git repositories
+in one go.
+
+It is part of the Selfie project of the Computational Systems Group
+at the Department of Computer Sciences of the University of Salzburg
+in Austria (http://selfie.cs.uni-salzburg.at).
+
+For more detailed information about its usage, please consult the
+enclosed README.
+'''
 
 bulk_grade_mode = False
 file_with_commit_links = None
@@ -216,7 +232,7 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
         return parse_assignment(assignment, assignments)
 
     parser = ArgumentParser(argv[0], formatter_class=RawDescriptionHelpFormatter,
-            epilog=list_assignments_str(assignments))
+            description=GRADER_SYNOPSIS, epilog=list_assignments_str(assignments))
 
     parser.add_argument('-q', action='store_true', default=False,
             help='only the grade is printed', dest='quiet')

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -242,7 +242,8 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
     parser.add_argument('-d', default=None, metavar="<directory>",
             help='path where all bulk graded repositories should be saved',
             dest='bulk_directory')
-    parser.add_argument('assignment', metavar='assignment', nargs='?', type=curried_parse_assignment)
+    parser.add_argument('assignment', metavar='assignment', nargs='?',
+            type=curried_parse_assignment, help='The assignment to test')
 
     try:
         if len(argv) <= 1:

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -212,6 +212,9 @@ def reset_state():
 
 
 def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: Assignment):
+    def curried_parse_assignment(assignment: str) -> Optional[Assignment]:
+        return parse_assignment(assignment, assignments)
+
     parser = ArgumentParser(argv[0], formatter_class=RawDescriptionHelpFormatter,
             epilog=list_assignments_str(assignments))
 
@@ -223,7 +226,7 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
     parser.add_argument('-d', default=None, metavar="<directory>",
             help='path where all bulk graded repositories should be saved',
             dest='bulk_directory')
-    parser.add_argument('assignment', metavar='assignment', nargs='?')
+    parser.add_argument('assignment', metavar='assignment', nargs='?', type=curried_parse_assignment)
 
     try:
         if len(argv) <= 1:
@@ -234,8 +237,6 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
 
         args = parser.parse_args(argv[1:])
 
-        assignment = parse_assignment(args.assignment, assignments)
-
         if args.quiet:
             enter_quiet_mode()
 
@@ -245,12 +246,12 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
         if args.bulk_directory:
             set_bulk_grade_directory(args.bulk_directory)
 
-        validate_options_for(assignment)
+        validate_options_for(args.assignment)
 
         if bulk_grade_mode:
-            do_bulk_grading(assignment, baseline)
+            do_bulk_grading(args.assignment, baseline)
         else:
-            check_assignment(assignment, baseline)
+            check_assignment(args.assignment, baseline)
 
     finally:
         reset_state()

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -233,7 +233,6 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
         set_home_path(Path(os.path.abspath(os.path.dirname(argv[0]))))
 
         args = parser.parse_args(argv[1:])
-        print(args)
 
         assignment = parse_assignment(args.assignment, assignments)
 

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -44,14 +44,11 @@ def list_assignments_str(assignments: List[Assignment]) -> str:
     return stream.getvalue()
 
 
-def parse_assignment(args: List[str], assignments: Set[Assignment]) -> Optional[Assignment]:
-    if len(args) == 0:
+def parse_assignment(args: str, assignments: Set[Assignment]) -> Optional[Assignment]:
+    if not args:
         return None
 
-    if len(args) > 1:
-        error('only 1 assignment allowed')
-
-    possible_assignment = list(filter(lambda a: a.name == args[0], assignments))
+    possible_assignment = list(filter(lambda a: a.name == args, assignments))
 
     if len(possible_assignment) == 1:
         return possible_assignment[0]
@@ -226,7 +223,7 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
     parser.add_argument('-d', default=None, metavar="<directory>",
             help='path where all bulk graded repositories should be saved',
             dest='bulk_directory')
-    parser.add_argument('assignment', metavar='assignment', nargs='*')
+    parser.add_argument('assignment', metavar='assignment', nargs='?')
 
     try:
         if len(argv) <= 1:

--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -23,33 +23,6 @@ def print_loud(msg, end='\n'):
     sys.stdout = quiet_writer
 
 
-def print_usage(options, assignments: List[Assignment]):
-    println('Usage: python3 grader/self.py { option } <test>\n')
-
-    println('Options:')
-
-    width = max(
-        map(lambda x: 0 if x[2] is None else len(x[2]), options))
-
-    for option in options:
-        println('  {0} {1:{width}}  {2}'.format(
-            option[0], option[2] if option[2] is not None else '', option[3], width=width))
-
-    println()
-
-    def print_assignment_of_lecture(lecture):
-        println(lecture + ' Assignments:')
-
-        for assignment in filter(lambda x: x.lecture is lecture, assignments):
-            println('  {}'.format(assignment.name))
-
-        println()
-
-    print_assignment_of_lecture('General')
-    print_assignment_of_lecture('Compiler')
-    print_assignment_of_lecture('OS')
-
-
 def print_grade(grade):
     colors = {'2': 92, '3': 93, '4': 93, '5': 91}
 


### PR DESCRIPTION
This PR changes replaces the custom argument parser with the `argparse` Python library.