### PR TITLE
Grader: Fix negative tests of `assembler-parser` assignments

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -202,11 +202,11 @@ def check_assembler_parser() -> List[Check]:
         check_execution('./selfie -a <assignment>valid-hex.s',
                         'assembly file with valid hex numbers') + \
         check_execution('./selfie -a <assignment>invalid-argument.s',
-                        'assembly file with a invalid argument is not parseable', success_criteria=False) + \
+                        'assembly file with a invalid argument is not parseable', should_succeed=False) + \
         check_execution('./selfie -a <assignment>missing-instruction.s',
-                        'assembly file with a missing instruction is not parseable', success_criteria=False) + \
+                        'assembly file with a missing instruction is not parseable', should_succeed=False) + \
         check_execution('./selfie -a <assignment>missing-literal.s',
-                        'assembly file with a missing literal is not parseable', success_criteria=False)
+                        'assembly file with a missing literal is not parseable', should_succeed=False)
 
 
 def check_self_assemblation() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -196,11 +196,11 @@ def check_assembler_parser() -> List[Check]:
     return check_execution('./selfie -c selfie.c -s selfie.s -a selfie.s',
                            'selfie can parse its own implementation in assembly') + \
         check_execution('./selfie -a <assignment>valid-registers-add.s',
-                           'assembly file with valid register access for RISC-U add instruction') + \
+                        'assembly file with valid register access for RISC-U add instruction') + \
         check_execution('./selfie -a <assignment>valid-registers-addi.s',
-                           'assembly file with valid register access for RISC-U addi instruction') + \
+                        'assembly file with valid register access for RISC-U addi instruction') + \
         check_execution('./selfie -a <assignment>valid-hex.s',
-                           'assembly file with valid hex numbers') + \
+                        'assembly file with valid hex numbers') + \
         check_execution('./selfie -a <assignment>invalid-argument.s',
                         'assembly file with a invalid argument is not parseable', success_criteria=False) + \
         check_execution('./selfie -a <assignment>missing-instruction.s',


### PR DESCRIPTION
@FrieAT reported an error on Slack regarding the handling of the negative tests of `assembler-parser`.
To specify that we actually expect the tests to fail, it must be specified using parameter `should_succeed` instead of `success_criteria`.