### PR TITLE
Fix file name typo in the grader (assembler-parser)

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -201,7 +201,7 @@ def check_assembler_parser() -> List[Check]:
                         'assembly file with valid register access for RISC-U addi instruction') + \
         check_execution('./selfie -a <assignment>valid-hex.s',
                         'assembly file with valid hex numbers') + \
-        check_execution('./selfie -a <assignment>invalid-argument.s',
+        check_execution('./selfie -a <assignment>invalid-argument-add.s',
                         'assembly file with a invalid argument is not parseable', should_succeed=False) + \
         check_execution('./selfie -a <assignment>missing-instruction.s',
                         'assembly file with a missing instruction is not parseable', should_succeed=False) + \


### PR DESCRIPTION
Fixes a typo in the file name of a recently added assembler-parser test.