### PR TITLE
Machine: Clean opensbi platform directory after selfie-opensbi.elf build

### DIFF
--- a/machine/defines.mk
+++ b/machine/defines.mk
@@ -181,6 +181,7 @@ define generate-target-sbi-elf
 $$(TARGET_$(1)_$(2)_DIR)/selfie-opensbi.elf: $$(TARGET_$(1)_$(2)_DIR)/selfie.bin | opensbi
 	$$(MAKE) -C opensbi CROSS_COMPILE=$$(PREFIX) PLATFORM_RISCV_XLEN=64 PLATFORM=$$(BOARD_$(1)_SBI_NAME) O=build/ FW_PAYLOAD=y FW_PAYLOAD_PATH=$$(realpath $$<) FW_TEXT_START=$$(BOARD_$(1)_PAYLOAD_START) FW_PAYLOAD_OFFSET=$$(BOARD_$(1)_PAYLOAD_OFFSET)
 	mv opensbi/build/platform/$$(BOARD_$(1)_SBI_NAME)/firmware/fw_payload.elf $$@
+	rm -r opensbi/build/platform/$$(BOARD_$(1)_SBI_NAME)/firmware/*
 
 .PHONY: selfie-opensbi-$(1)-$(2).elf
 selfie-opensbi-$(1)-$(2).elf: $$(TARGET_$(1)_$(2)_DIR)/selfie-opensbi.elf


### PR DESCRIPTION
OpenSBI's makefile target `all` declares prerequisites on the
fw_payload.bin file of the specified platform, which itself depends on
the fw_payload.elf file that we move out after the build has finished.
As the fw_payload.bin file still exists, make does not look further and
does not rebuild fw_payload.elf.

Instead, remove the whole firmware/ subdirectory of the platform's build
output directory. This is preferrable to a `make clean` because this
would also clean shared build artifacts.

The relevant lines of this behavior are (in OpenSBI v0.7):
- opensbi/firmware/objects.mk:30
- opensbi/Makefile:134
- opensbi/Makefile:300
- opensbi/Makefile:304