### PR TITLE
Grader: Don't re-assemble binary on Mipster in 'self-assembler' (fixes #229)

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -210,10 +210,10 @@ def check_assembler_parser() -> List[Check]:
 
 
 def check_self_assemblation() -> List[Check]:
-    return check_execution('./selfie -c selfie.c -s selfie1.s -a selfie1.s -m 128 -a selfie1.s -s selfie2.s ',
-                           'selfie can assemble its own binary file') + \
-        check_execution('diff -q selfie1.s selfie2.s',
-                        'both assembly files are exactly the same')
+    return check_execution('./selfie -c selfie.c -s selfie1.s -a selfie1.s -o selfie1.m -m 128 -c selfie.c -o selfie2.m',
+                           'selfie can re-assemble its own binary file') + \
+        check_execution('diff -q selfie1.m selfie2.m',
+                        'both binary files are exactly the same')
 
 
 def check_processes() -> List[Check]:


### PR DESCRIPTION
Currently, the `self-assembler` check causes a timeout for some
implementations. This is due to the assemble and disassemble step taking
rather long.

This commit instead emits two binaries. The first is generated by the
host's selfie by compiling, disassembling and re-assembling `selfie.c`.
The resulting binary is then run by Mipster to compile the source again
and emit the binary. If the assemble-step succeeded, the re-assembled
binary should emit itself and thus both binaries should be equivalent.