### PR TITLE
Grader: Fix assignment `self-assembler` passing without implementation

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -213,9 +213,9 @@ def check_self_assemblation() -> List[Check]:
     return check_execution('./selfie -c selfie.c -s selfie1.s',
                            'preparation: selfie can compile and assemble its own source', mandatory=True) + \
         check_execution('./selfie -a selfie1.s -o selfie1.m -m 128 -c selfie.c -o selfie2.m',
-                        'selfie can re-assemble its own binary file') + \
+                        'selfie can re-assemble its own binary file', mandatory=True) + \
         check_execution('diff -q selfie1.m selfie2.m',
-                        'both binary files are exactly the same')
+                        'both binary files are exactly the same', mandatory=True)
 
 
 def check_processes() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -210,8 +210,10 @@ def check_assembler_parser() -> List[Check]:
 
 
 def check_self_assemblation() -> List[Check]:
-    return check_execution('./selfie -c selfie.c -s selfie1.s -a selfie1.s -o selfie1.m -m 128 -c selfie.c -o selfie2.m',
-                           'selfie can re-assemble its own binary file') + \
+    return check_execution('./selfie -c selfie.c -s selfie1.s',
+                           'preparation: selfie can compile and assemble its own source', mandatory=True) + \
+        check_execution('./selfie -a selfie1.s -o selfie1.m -m 128 -c selfie.c -o selfie2.m',
+                        'selfie can re-assemble its own binary file') + \
         check_execution('diff -q selfie1.m selfie2.m',
                         'both binary files are exactly the same')
 


### PR DESCRIPTION
@fischer-martin informed me that the change made by #229 introduced a
bug.
The assignment will falsely succeed when support for the `-a` flag
has been implemented, but no changes to global `binary` have
been made. This is due to the previously compiled and disassembled
binary still being in memory.

This PR splits the first execution check into a preparation step that
compiles and disassembles `selfie.c` and another check that does the
assemble step, binary output, mipster compilation and binary output.