### PR TITLE
Grader: Don't fail assignment if it contains mandatory checks only

### DIFF
--- a/grader/lib/grade.py
+++ b/grader/lib/grade.py
@@ -34,17 +34,19 @@ def grade(results: List[CheckResult]) -> Tuple[int, List[str]]:
     failed_mandatory_test = any(
         filter(lambda x: x.result != x.should_succeed, mandatory_tests))
 
-    if number_of_tests_passed == 0:
+    if number_of_tests_passed == 0 and number_of_tests != 0:
         passed = 0.0
+    elif number_of_tests_passed == 0 and number_of_tests == 0: # No tests or only mandatory tests
+        passed = 1.0
     else:
         passed = number_of_tests_passed / float(number_of_tests)
 
     reasons = [ ]
 
-    if failed_mandatory_test or number_of_positive_tests_passed == 0:
+    if failed_mandatory_test or (number_of_positive_tests_passed == 0 and number_of_tests != 0):
         if failed_mandatory_test:
             reasons.append('you have failed a mandatory test')
-        if number_of_positive_tests_passed == 0:
+        if number_of_positive_tests_passed == 0 and number_of_tests != 0:
             reasons.append('you have not passed at least one positive test')
 
         grade = 5


### PR DESCRIPTION
The grader does naturally not include mandatory checks into the
calculation of a student's grade. If there were no positive checks, the
grader will explicitly set the amount of `passed` tests to 0%.
Furthermore, it will add string `you have not passed at least one
positive test` to the reasons grade 5 was given.
Unfortunately, if an assignment contains mandatory tests only (important
for all-or-nothing assignments), the grader mistakenly sets 0% passed
rate. This is due to mandatory tests not being added to the check
counters. As there are no non-mandatory tests, there cannot be any
passed non-mandatory tests.
This commit adds an check whether `number_of_tests` is zero (either
mandatory tests only or no tests at all). In this case, the rate of
passed tests is explicitly set to 100%.