### PR TITLE
Fix grader workflow failing due to the deprecation of set-env

### DIFF
--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -25,6 +25,6 @@ jobs:
         python-version: "3.7.x"
     # extract assignment from "commit message [assignment]"
     - name: Parse commit message
-      run: echo ::set-env name=ASSIGNMENT::$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')
+      run: echo "ASSIGNMENT=$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')" >> $GITHUB_ENV
     - name: Autograde assignment
       run: if [ "$ASSIGNMENT" != 'skip ci' ]; then ./grader/self.py $ASSIGNMENT; fi


### PR DESCRIPTION
The grader workflow failed due to the deprecation of `set-env` (see [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)). Example message:
```
Error: Unable to process command '::set-env name=ASSIGNMENT::processes' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This is fixed by setting the `ASSIGNMENT` environment variable in the way described [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).