### PR TITLE
Grader: Allow SIGINT to be handled when waiting for a subprocess (fixes #144)

### DIFF
--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -4,7 +4,7 @@ import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from io import StringIO
 from pathlib import Path
-from subprocess import run
+from subprocess import run, DEVNULL
 from typing import Callable, Optional, List, Tuple, Dict, Set
 
 from lib.functional import flatmap
@@ -172,24 +172,26 @@ def do_bulk_grading(assignment: Optional[Assignment], base_test: Assignment):
             clone_dir = os.path.join(bulk_grade_directory, repo_id)
 
             if not os.path.exists(clone_dir):
-                status = os.system(
-                    'git clone -q git@github.com:{} {} >/dev/null 2>&1'.format(repo_id, repo_id))
+                status = run(
+                        ['git', 'clone', '-q', 'git@github.com:{}'.format(repo_id), repo_id],
+                        stdout=DEVNULL, stderr=DEVNULL).returncode
 
                 if status != 0:
-                    print_message('error when cloning ' + repo_id, loud=True)
+                    print_message('error while cloning ' + repo_id, loud=True)
                     continue
 
             os.chdir(clone_dir)
 
             # remove all changes in local repository
-            os.system('git reset --hard -q >/dev/null 2>&1')
+            run(['git', 'reset', '--hard', '-q'], stdout=DEVNULL, stderr=DEVNULL)
 
             # fetch updates from github repository
-            os.system('git fetch -q >/dev/null 2>&1')
+            run(['git', 'fetch', '-q'], stdout=DEVNULL, stderr=DEVNULL)
 
             # change the local repository state using the commit ID
-            status = os.system(
-                'git checkout -q {} >/dev/null 2>&1'.format(info['commit']))
+            status = run(
+                    ['git', 'checkout', '-q', info['commit']],
+                    stdout=DEVNULL, stderr=DEVNULL).returncode
 
             if status == 0:
                 if assignment is None:

--- a/grader/tests/test_bulk_grader.py
+++ b/grader/tests/test_bulk_grader.py
@@ -2,17 +2,16 @@ import unittest
 import sys
 import re
 import os
+import subprocess
 # from os import system
 from os.path import isfile
 import shlex
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, run
 from unittest.mock import patch
 
 from self import main as grader_main
 from lib.print import println
 from tests.utils import CaptureOutput, compile_with_gcc_and_run
-
-system = os.system
 
 
 class ExitError(Exception):
@@ -22,10 +21,10 @@ class ExitError(Exception):
 
 class TestBulkGrader(unittest.TestCase):
 
-    def commit_without_auth(self, command):
-        return system(command.replace('git@github.com:', 'https://github.com/'))
+    def commit_without_auth(self, command, **kwargs):
+        return run([arg.replace('git@github.com:', 'https://github.com/') for arg in command], **kwargs)
 
-    @patch('os.system')
+    @patch('lib.cli.run') # imported from subprocess
     def test_bulk_grading_with_wrong_arguments(self, mock):
         mock.side_effect = self.commit_without_auth
 
@@ -44,7 +43,7 @@ class TestBulkGrader(unittest.TestCase):
             raise ExitError(code)
 
     @patch('lib.cli.exit')
-    @patch('os.system')
+    @patch('lib.cli.run') # imported from subprocess
     def test_bulk_grading(self, mock, exit_mock):
         mock.side_effect = self.commit_without_auth
 


### PR DESCRIPTION
When forking a child process, both the parent and the children reside in
the same process group. Signals like SIGINT that directed to a process
group will be distributed to all processes in the group. However, the
grader did not receive SIGINT when issuing [Ctrl]+[C] in a hosting
terminal. This is due to to the grader using `system` to start the child
processes.

As per the man-pages of `system` for
[FreeBSD](https://www.unix.com/man-page/freebsd/3/system/),
[macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/system.3.html)
and [Linux](https://linux.die.net/man/3/system), signal `SIGINT` will be
ignored while the application waits for the child process to finish.
Unfortunately, the return value of Python's `os.system` is
platform-dependent.

This commit instead uses `subprocess.run` which under the hood calls an
`execve`-like function. SIGINT will not be masked by this and will be
received by both the child `git` processes and the parent grader
process.