### PR TITLE
fix compiler warning regarding malloc for 32-bit build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ selfie: selfie.c
 	$(CC) $(CFLAGS) $< -o $@
 
 # 32-bit compiler flags
-32-BIT-CFLAGS := -Wall -Wextra -Wno-builtin-declaration-mismatch -O3 -m32 -D'uint64_t=unsigned long'
+32-BIT-CFLAGS := -Wall -Wextra -O3 -m32 -D'uint64_t=unsigned long' -D'long=int'
 
 # Bootstrap selfie.c into 32-bit selfie executable, requires 32-bit compiler support
 selfie-32: selfie.c


### PR DESCRIPTION
This fixes the compiler warning that comes up due to the type of the parameter in the `malloc(unsigned long)` declaration. While this works on AMD64 (Linux), it is a dangerous game we are playing here since the `long=int` macro causes the `uint64_t=unsigned long` macro to be implicitly transformed into `uint64_t=unsigned int`. This is obviously problematic for systems where `sizeof(int) != 4`.

Another fix I could think of would be to change the malloc declaration to `malloc(size_t size)` which would require bootstrapping `size_t` (instead of `unsigned`) to `uint64_t` and to add the macros `size_t=unsigned long long` (64-bit) and `size_t=unsigned int` (32-bit) to the CFLAGS.