### PR TITLE
docs: fix simple typo, specifc -> specific

### DIFF
--- a/grader/assignments/fork-wait/parallel-print.c
+++ b/grader/assignments/fork-wait/parallel-print.c
@@ -59,7 +59,7 @@ void parallel_print(uint64_t depth) {
 
     write(1, sorted_numbers + process_identity, 2);
   } else {
-    // save process id for a specifc depth
+    // save process id for a specific depth
     *(pids + depth) = fork();
 
     // parallel_print here is called 2 times

--- a/grader/assignments/fork-wait/sum-exit-code.c
+++ b/grader/assignments/fork-wait/sum-exit-code.c
@@ -56,7 +56,7 @@ uint64_t parallel_sum(uint64_t depth) {
 
     return *(sorted_numbers + process_identity);
   } else {
-    // save process id for a specifc depth
+    // save process id for a specific depth
     *(pids + depth) = fork();
 
     // parallel_print here is called 2 times


### PR DESCRIPTION
There is a small typo in grader/assignments/fork-wait/parallel-print.c, grader/assignments/fork-wait/sum-exit-code.c.

Should read `specific` rather than `specifc`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md