### PR TITLE
Grader: Add more checks to `fork-wait-exit`

### DIFF
--- a/grader/assignments/fork-wait/invalid-address.c
+++ b/grader/assignments/fork-wait/invalid-address.c
@@ -11,9 +11,9 @@ uint64_t wexitstatus(uint64_t status) {
 int main() {
   uint64_t sum;
   uint64_t pid;
-  uint64_t* code;
+  uint64_t* heap_top;
 
-  code = malloc(8);
+  heap_top = malloc(8);
   sum = 38;
 
   pid = fork();
@@ -26,8 +26,8 @@ int main() {
 
     // Second invalid access - free region between stack and heap
     // Bump pointer allocation -> we can derive the end of the heap
-    // using the most recently allocated memory block, in this case `code`
-    pid = wait(code + 1);
+    // using the most recently allocated memory block, in this case `heap_top`
+    pid = wait(heap_top + 1);
     sum = sum + pid;
 
     // Third invalid address - outside the 4GiB virtual addressing space
@@ -37,8 +37,8 @@ int main() {
 
   // Actually query the PID/status
   // The previous calls should have failed before and mustn't have consumed the zombie
-  pid = wait(code);
+  pid = wait(heap_top);
 
   // 38 (initial) + 5 (exit code) + 2 (PID) + 3 * (-1) (wait error on invalid vaddr)
-  return sum + pid + wexitstatus(*code);
+  return sum + pid + wexitstatus(*heap_top);
 }

--- a/grader/assignments/fork-wait/invalid-address.c
+++ b/grader/assignments/fork-wait/invalid-address.c
@@ -1,0 +1,16 @@
+uint64_t VIRTUALMEMORYSIZE = 4294967296; // 4GB of virtual memory
+
+int main() {
+  uint64_t pid;
+  uint64_t* code;
+
+  code = (uint64_t*) VIRTUALMEMORYSIZE;
+
+  pid = fork();
+  if (pid == 0)
+      exit(0);
+  else
+      pid = wait(code);
+
+  return 43 + pid;
+}

--- a/grader/assignments/fork-wait/invalid-address.c
+++ b/grader/assignments/fork-wait/invalid-address.c
@@ -1,16 +1,28 @@
 uint64_t VIRTUALMEMORYSIZE = 4294967296; // 4GB of virtual memory
 
+// computes the exit code from the status value
+// exit code is in the least significant bits from 8 to 16
+uint64_t wexitstatus(uint64_t status) {
+  return status * 281474976710656 / 72057594037927936;
+}
+
 int main() {
-  uint64_t pid;
+  uint64_t pid1;
+  uint64_t pid2;
   uint64_t* code;
 
   code = (uint64_t*) VIRTUALMEMORYSIZE;
 
-  pid = fork();
-  if (pid == 0)
-      exit(0);
+  pid1 = fork();
+  if (pid1 == 0)
+    exit(5);
   else
-      pid = wait(code);
+    pid1 = wait(code);
 
-  return 43 + pid;
+  // Actually query the PID/status
+  // The previous call should have failed before, but mustn't have consumed the zombie
+  code = malloc(8);
+  pid2 = wait(code);
+
+  return 36 + pid1 + pid2 + wexitstatus(*code);
 }

--- a/grader/assignments/fork-wait/invalid-address.c
+++ b/grader/assignments/fork-wait/invalid-address.c
@@ -1,4 +1,6 @@
-uint64_t VIRTUALMEMORYSIZE = 4294967296; // 4GB of virtual memory
+uint64_t* VIRTUALMEMORYSIZE = (uint64_t*) 4294967296; // 4GB of virtual memory
+uint64_t* ELF_ENTRY_POINT = (uint64_t*) 65536; // = 0x10000 (address of beginning of code)
+
 
 // computes the exit code from the status value
 // exit code is in the least significant bits from 8 to 16
@@ -7,22 +9,36 @@ uint64_t wexitstatus(uint64_t status) {
 }
 
 int main() {
-  uint64_t pid1;
-  uint64_t pid2;
+  uint64_t sum;
+  uint64_t pid;
   uint64_t* code;
 
-  code = (uint64_t*) VIRTUALMEMORYSIZE;
+  code = malloc(8);
+  sum = 38;
 
-  pid1 = fork();
-  if (pid1 == 0)
+  pid = fork();
+  if (pid == 0)
     exit(5);
-  else
-    pid1 = wait(code);
+  else {
+    // First invalid access - code segment
+    pid = wait(ELF_ENTRY_POINT);
+    sum = sum + pid;
+
+    // Second invalid access - free region between stack and heap
+    // Bump pointer allocation -> we can derive the end of the heap
+    // using the most recently allocated memory block, in this case `code`
+    pid = wait(code + 1);
+    sum = sum + pid;
+
+    // Third invalid address - outside the 4GiB virtual addressing space
+    pid = wait(VIRTUALMEMORYSIZE);
+    sum = sum + pid;
+  }
 
   // Actually query the PID/status
-  // The previous call should have failed before, but mustn't have consumed the zombie
-  code = malloc(8);
-  pid2 = wait(code);
+  // The previous calls should have failed before and mustn't have consumed the zombie
+  pid = wait(code);
 
-  return 36 + pid1 + pid2 + wexitstatus(*code);
+  // 38 (initial) + 5 (exit code) + 2 (PID) + 3 * (-1) (wait error on invalid vaddr)
+  return sum + pid + wexitstatus(*code);
 }

--- a/grader/assignments/fork-wait/null-ptr.c
+++ b/grader/assignments/fork-wait/null-ptr.c
@@ -7,9 +7,8 @@ int main() {
   pid = fork();
   if (pid == 0)
     exit(0);
-  else {
+  else
     pid = wait(NULL);
-  }
 
   return pid;
 }

--- a/grader/assignments/fork-wait/null-ptr.c
+++ b/grader/assignments/fork-wait/null-ptr.c
@@ -1,14 +1,20 @@
 uint64_t* NULL = (uint64_t*) 0;
 
 int main() {
-  uint64_t pid;
+  uint64_t fork_pid;
+  uint64_t wait_pid;
   uint64_t i;
 
-  pid = fork();
-  if (pid == 0)
+  fork_pid = fork();
+  if (fork_pid == 0)
     exit(0);
   else
-    pid = wait(NULL);
+    wait_pid = wait(NULL);
 
-  return 21 * pid;
+  if (fork_pid == -1)
+    return 1;
+  if (wait_pid == -1)
+    return 2;
+
+  return 42 + (fork_pid - wait_pid);
 }

--- a/grader/assignments/fork-wait/null-ptr.c
+++ b/grader/assignments/fork-wait/null-ptr.c
@@ -10,5 +10,5 @@ int main() {
   else
     pid = wait(NULL);
 
-  return pid;
+  return 21 * pid;
 }

--- a/grader/assignments/fork-wait/null-ptr.c
+++ b/grader/assignments/fork-wait/null-ptr.c
@@ -1,0 +1,15 @@
+uint64_t* NULL = (uint64_t*) 0;
+
+int main() {
+  uint64_t pid;
+  uint64_t i;
+
+  pid = fork();
+  if (pid == 0)
+    exit(0);
+  else {
+    pid = wait(NULL);
+  }
+
+  return pid;
+}

--- a/grader/assignments/fork-wait/unmapped-page-wait.c
+++ b/grader/assignments/fork-wait/unmapped-page-wait.c
@@ -1,3 +1,9 @@
+// computes the exit code from the status value
+// exit code is in the least significant bits from 8 to 16
+uint64_t wexitstatus(uint64_t status) {
+  return status * 281474976710656 / 72057594037927936;
+}
+
 int main() {
   uint64_t pid;
   uint64_t* code;
@@ -18,5 +24,5 @@ int main() {
     wait(code + 4095);
   }
 
-  return 21 + *(code + 4095) / 1024;
+  return 21 + wexitstatus(*(code + 4095)) / 4;
 }

--- a/grader/assignments/fork-wait/unmapped-page-wait.c
+++ b/grader/assignments/fork-wait/unmapped-page-wait.c
@@ -1,0 +1,22 @@
+int main() {
+  uint64_t pid;
+  uint64_t* code;
+
+  // Enforce an unmapped virtual address by allocating a page-wide array
+  // and not touching it
+  // It must be page-wide to move the last element across potential already
+  // mapped page boundaries
+  // wait uses the last element, then
+  code = malloc(8 * 4096);
+
+  pid = fork();
+  if (pid == 0) {
+    // Child process - return
+    exit(84);
+  } else {
+    // Parent process - wait for the child and calculate the exit code;
+    wait(code + 4095);
+  }
+
+  return 21 + *(code + 4095) / 1024;
+}

--- a/grader/assignments/fork-wait/unmapped-page-wait.c
+++ b/grader/assignments/fork-wait/unmapped-page-wait.c
@@ -6,23 +6,22 @@ uint64_t wexitstatus(uint64_t status) {
 
 int main() {
   uint64_t pid;
-  uint64_t* code;
+  uint64_t* exit_code;
 
   // Enforce an unmapped virtual address by allocating a page-wide array
   // and not touching it
   // It must be page-wide to move the last element across potential already
   // mapped page boundaries
   // wait uses the last element, then
-  code = malloc(8 * 4096);
+  exit_code = malloc(8 * 4096);
 
   pid = fork();
-  if (pid == 0) {
+  if (pid == 0)
     // Child process - return
     exit(84);
-  } else {
+  else
     // Parent process - wait for the child and calculate the exit code;
-    wait(code + 4095);
-  }
+    wait(exit_code + 4095);
 
-  return 21 + wexitstatus(*(code + 4095)) / 4;
+  return 21 + wexitstatus(*(exit_code + 4095)) / 4;
 }

--- a/grader/self.py
+++ b/grader/self.py
@@ -247,7 +247,7 @@ def check_fork_wait_exit() -> List[Check]:
                                 'wait system call maps page to unmapped virtual address') + \
         check_mipster_execution('invalid-address.c', 42,
                                 'wait system call correctly handles invalid addresses') + \
-        check_mipster_execution('null-ptr.c', 2,
+        check_mipster_execution('null-ptr.c', 42,
                                 'wait system call returns PID when NULL is passed');
 
 

--- a/grader/self.py
+++ b/grader/self.py
@@ -242,7 +242,9 @@ def check_fork_wait_exit() -> List[Check]:
         check_mipster_execution('sum-exit-code.c', 28,
                                 'exit code is returned as status parameter from wait with MIPSTER') + \
         check_hypster_execution('sum-exit-code.c', 28,
-                                'exit code is returned as status parameter from wait with HYPSTER')
+                                'exit code is returned as status parameter from wait with HYPSTER') + \
+        check_mipster_execution('unmapped-page-wait.c', 42,
+                                'wait system call maps page to unmapped virtual address')
 
 
 def check_lock() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -246,7 +246,7 @@ def check_fork_wait_exit() -> List[Check]:
         check_mipster_execution('unmapped-page-wait.c', 42,
                                 'wait system call maps page to unmapped virtual address') + \
         check_mipster_execution('invalid-address.c', 42,
-                                'wait system call returns error when an invalid address is passed')
+                                'wait system call correctly handles invalid addresses')
 
 
 def check_lock() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -244,7 +244,9 @@ def check_fork_wait_exit() -> List[Check]:
         check_hypster_execution('sum-exit-code.c', 28,
                                 'exit code is returned as status parameter from wait with HYPSTER') + \
         check_mipster_execution('unmapped-page-wait.c', 42,
-                                'wait system call maps page to unmapped virtual address')
+                                'wait system call maps page to unmapped virtual address') + \
+        check_mipster_execution('invalid-address.c', 42,
+                                'wait system call returns error when an invalid address is passed')
 
 
 def check_lock() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -246,7 +246,9 @@ def check_fork_wait_exit() -> List[Check]:
         check_mipster_execution('unmapped-page-wait.c', 42,
                                 'wait system call maps page to unmapped virtual address') + \
         check_mipster_execution('invalid-address.c', 42,
-                                'wait system call correctly handles invalid addresses')
+                                'wait system call correctly handles invalid addresses') + \
+        check_mipster_execution('null-ptr.c', 2,
+                                'wait system call returns PID when NULL is passed');
 
 
 def check_lock() -> List[Check]:

--- a/grader/tests/utils.py
+++ b/grader/tests/utils.py
@@ -102,7 +102,6 @@ not_compilable = [
     'assembler-parser',
     'self-assembler',
     'processes',
-    'fork-wait-exit',
     'lock',
     'threads',
     'treiber-stack'

--- a/grader/tests/utils.py
+++ b/grader/tests/utils.py
@@ -102,6 +102,7 @@ not_compilable = [
     'assembler-parser',
     'self-assembler',
     'processes',
+    'fork-wait-exit',
     'lock',
     'threads',
     'treiber-stack'


### PR DESCRIPTION
This commit introduces two more checks to the `fork-wait-exit` assignment.

* The first check asserts whether the `wait` implementation handles unmapped virtual addresses and maps pages accordingly. If the syscall does not handle it properly, Selfie will probably raise a SEGFAULT signal.
* The second check asserts whether `wait` handles invalid addresses outside the 4GiB correctly and returns -1 instead of a terminated child's PID.