### PR TITLE
Grader: Add `--truncate` option

### DIFF
--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -11,7 +11,7 @@ from lib.functional import flatmap
 from lib.model import Assignment, Check, CheckResult
 from lib.grade import grade
 from lib.checks import set_home_path, set_assignment_name
-from lib.print import (is_in_quiet_mode, enter_quiet_mode, leave_quiet_mode, print_error,
+from lib.print import (enter_quiet_mode, leave_quiet_mode, print_error,
                        print_message, print_warning, print_grade, print_processing,
                        stop_processing_spinner, print_passed, print_failed,
                        reset_truncate, set_truncate)
@@ -80,7 +80,7 @@ def parse_truncate_range(arg: str) -> int:
 
 
 def validate_options_for(assignment: Optional[Assignment]):
-    if not bulk_grade_mode and is_in_quiet_mode() and assignment is None:
+    if not bulk_grade_mode and assignment is None:
         error('please specify an assignment')
 
 

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -71,8 +71,8 @@ def parse_truncate_range(arg: str) -> int:
     try:
         value = int(arg)
 
-        if value < -1:
-            raise ArgumentTypeError("truncate line count must be -1 (unlimited), 0 (omitted) or positive")
+        if value < 0:
+            raise ArgumentTypeError("truncate line count must be a natural number")
 
         return value
     except ValueError:
@@ -254,7 +254,7 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
             dest='bulk_directory')
     parser.add_argument('--truncate', metavar=('trailing', 'leading'), nargs=2,
             type=parse_truncate_range,
-            help='truncates the amount of leading and trailing lines (-1 for unlimited output)',
+            help='truncates the amount of leading and trailing lines',
             dest='truncate')
     parser.add_argument('assignment', metavar='assignment', nargs='?',
             type=curried_parse_assignment, help='grade this assignment')

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -239,6 +239,10 @@ def process_arguments(argv: List[str], assignments: Set[Assignment], baseline: A
     parser.add_argument('-d', default=None, metavar="<directory>",
             help='directory where all bulk-graded repositories are stored',
             dest='bulk_directory')
+    parser.add_argument('--truncate', metavar=('trailing', 'leading'), nargs=2,
+            type=int, default=[-1, -1],
+            help='truncates the amount of leading and trailing lines',
+            dest='truncate')
     parser.add_argument('assignment', metavar='assignment', nargs='?',
             type=curried_parse_assignment, help='grade this assignment')
 

--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -2,9 +2,10 @@ import os
 import sys
 import time
 import threading
-from typing import List
+from typing import List, Tuple
 
 from lib.model import Assignment
+from lib.string import nfind, nrfind
 
 def println(line='', end='\n', loud=False):
     if loud:
@@ -36,12 +37,29 @@ def print_passed(msg):
     println("\033[92m[PASSED]\033[0m " + msg)
 
 
-def print_failed(msg, warning, output, command):
+def print_failed(msg, warning, output: str, command):
     println("\033[91m[FAILED]\033[0m " + msg)
     if command != None:
         println(command)
     if warning != None:
         println("\033[93m > " + warning + " <\033[0m")
+
+    # The output has to be truncated if neither head nor tail are unlimited
+    if get_truncate_head() != -1 and get_truncate_tail() != -1:
+        # and the amount of lines in the output exceeds the bounds
+        totalMaxLines = get_truncate_head() + get_truncate_tail()
+        outputLines = output.count('\n')
+        if outputLines > totalMaxLines:
+            omittedLines = outputLines - totalMaxLines
+            head = nfind(output, '\n', get_truncate_head())
+            tail = nrfind(output, '\n', get_truncate_tail() + 1) # +1 due to empty last line
+
+
+            output = output[:head+1] + \
+                '----------8<---------- [{:3} lines truncated] ---------->8----------\n'.format(omittedLines) + \
+                output[tail+1:]
+
+
     println(' >> ' + output[:-1].replace('\n', '\n >> '))
 
 
@@ -123,3 +141,30 @@ def leave_quiet_mode():
         sys.stdout.close()
 
     sys.stdout = sys.__stdout__
+
+
+truncate_lines: Tuple[int, int] = (-1, -1)
+
+def get_truncate_head() -> int:
+    global truncate_lines
+    return truncate_lines[0]
+
+def get_truncate_tail() -> int:
+    global truncate_lines
+    return truncate_lines[1]
+
+def set_truncate_head(head: int):
+    global truncate_lines
+    truncate_lines[0] = head
+
+def set_truncate_tail(tail: int):
+    global truncate_lines
+    truncate_lines[1] = tail
+
+def set_truncate(head: int, tail: int):
+    global truncate_lines
+    truncate_lines = (head, tail)
+
+def reset_truncate():
+    global truncate_lines
+    truncate_lines = (-1, -1)

--- a/grader/lib/string.py
+++ b/grader/lib/string.py
@@ -1,0 +1,30 @@
+def nfind(text: str, pattern: str, n: int):
+    """
+    Finds the n-th occurrence of a pattern in a string.
+    This is done by calling str.find n times and passing the
+    previously found index + 1 as start.
+    """
+
+    pos = -1
+    for i in range(n):
+        pos = text.find(pattern, pos + 1)
+        if pos == -1:
+            return -1
+
+    return pos
+
+
+def nrfind(text: str, pattern: str, n: int):
+    """
+    Finds the n-th occurrence of a pattern in a string in reverse.
+    This is done by calling str.rfind n times and passing the
+    previously found index - 1 as end.
+    """
+
+    pos = len(text) + 1
+    for i in range(n):
+        pos = text.rfind(pattern, 0, pos - 1)
+        if pos == -1:
+            return -1
+
+    return pos


### PR DESCRIPTION
@fischer-martin asked me to add a truncate option to the grader because long debugging output make grading harder.

The option `--truncate <head> <tail>` takes two integral parameters that specify the amount of lines at the beginning or the end to print, respectively. By passing `-1` to at least one of these parameters, the output is unlimited, i.e. the flag is not effective.