### PR TITLE
Grader: Add release after exit check for `lock` assignment

### DIFF
--- a/grader/assignments/lock/release-after-exit.c
+++ b/grader/assignments/lock/release-after-exit.c
@@ -1,0 +1,28 @@
+uint64_t* foo_parent;
+uint64_t* foo_child;
+
+int main() {
+  uint64_t pid;
+  uint64_t* status;
+
+  status = malloc(8);
+  foo_parent = "Hello parent!   ";
+  foo_child  = "Hello child!    ";
+
+  pid = fork();
+  if (pid == 0) {
+    lock();
+    write(1, foo_child, 16);
+    // The lock will not be released intentionally before the child process terminates
+    exit(0);
+  } else {
+    pid = wait(status);
+
+    // If the implementation does not free the lock after the child holding it terminated,
+    // this call will block indefinitely
+    lock();
+    write(1, foo_parent, 16);
+    unlock();
+    exit(0);
+  }
+}

--- a/grader/lib/checks.py
+++ b/grader/lib/checks.py
@@ -206,12 +206,12 @@ def check_assembler_instruction_format(instruction, file) -> List[Check]:
     return [Check(msg, execute_check)]
 
 
-def check_execution(command, msg, success_criteria=True, should_succeed=True, mandatory=False) -> List[Check]:
+def check_execution(command, msg, success_criteria=True, should_succeed=True, mandatory=False, timeout=60) -> List[Check]:
     def execute_check() -> CheckResult:
         secure_command = insert_assignment_path(command)
 
         try:
-            returncode, output, error_output = execute(secure_command)
+            returncode, output, error_output = execute(secure_command, timeout)
 
             if returncode != 0 and len(output) == 0:
                 output = error_output

--- a/grader/self.py
+++ b/grader/self.py
@@ -266,7 +266,7 @@ def check_lock() -> List[Check]:
                         success_criteria='Hello World!    ' * 8) + \
         check_execution('./selfie -c <assignment>release-after-exit.c -m 128',
                         'Lock is granted to a process after a terminated process did not release its lock',
-                        success_criteria='Hello child!    Hello parent!   ')
+                        success_criteria='Hello child!    Hello parent!   ', timeout=5)
 
 
 def check_threads() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -263,7 +263,10 @@ def check_lock() -> List[Check]:
                         success_criteria='Hello World!    ' * 8) + \
         check_execution('./selfie -c selfie.c -m 128 -c <assignment>print-with-lock.c -y 10',
                         '16 processes are printing in sequential order with the use of locks on HYPSTER',
-                        success_criteria='Hello World!    ' * 8)
+                        success_criteria='Hello World!    ' * 8) + \
+        check_execution('./selfie -c <assignment>release-after-exit.c -m 128',
+                        'Locks that have not been released by a terminated child are released by the system',
+                        success_criteria='Hello child!    Hello parent!   ')
 
 
 def check_threads() -> List[Check]:

--- a/grader/self.py
+++ b/grader/self.py
@@ -265,7 +265,7 @@ def check_lock() -> List[Check]:
                         '16 processes are printing in sequential order with the use of locks on HYPSTER',
                         success_criteria='Hello World!    ' * 8) + \
         check_execution('./selfie -c <assignment>release-after-exit.c -m 128',
-                        'Locks that have not been released by a terminated child are released by the system',
+                        'Lock is granted to a process after a terminated process did not release its lock',
                         success_criteria='Hello child!    Hello parent!   ')
 
 

--- a/grader/tests/test_riscv_instruction.py
+++ b/grader/tests/test_riscv_instruction.py
@@ -20,7 +20,7 @@ class TestRiscvInstruction(unittest.TestCase):
         self.instructions = list(
             map(lambda f: f[:-2], list_files('tests/instructions', extension='.s')))
 
-    def execute_mock(self, command):
+    def execute_mock(self, command, timeout=60):
         if '.tmp.bin' in command:
             for instruction in self.instructions:
                 if instruction in command:

--- a/grader/tests/test_robustness.py
+++ b/grader/tests/test_robustness.py
@@ -16,8 +16,8 @@ class TestRobustness(TestCase):
     def setUp(self):
         rmtree(dst, ignore_errors=True)
 
-    def execute_mock(self, command):
-        ret_code, output, error_output = execute(command)
+    def execute_mock(self, command, timeout=60):
+        ret_code, output, error_output = execute(command, timeout)
 
         self.assertNotEqual(ret_code, EXITCODE_IOERROR)
 


### PR DESCRIPTION
This PR introduces an additional check to the `lock` assignment.
It asserts whether a lock held by terminated processes are released. The check creates a fork that takes a lock, prints a message and terminates. The parent waits for the child to terminate, tries to take the lock itself, prints a message, unlocks the lock and terminates itself.