### PR TITLE
Grader: Fix self-compilation and `fork-wait-exit` assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,14 @@ selfie.h: selfie.c
 	sed 's/main(/selfie_main(/' selfie.c > selfie.h
 
 # Consider these targets as targets, not files
-.PHONY: compile quine escape debug replay os vm min mob gib gclib giblib gclibtest sat mon smt mod btor2 selfie-2-x86 all assemble spike qemu x86 boolector btormc validator grader grade extras everything clean
+.PHONY: self self-self quine escape debug replay os vm min mob gib gclib giblib gclibtest sat mon smt mod btor2 selfie-2-x86 all assemble spike qemu x86 boolector btormc validator grader grade extras everything clean
 
-# Self-contained fixed-point of self-compilation
-compile: selfie
+# Self-compile selfie
+self: selfie
+	./selfie -c selfie.c
+
+# Self-self-compile selfie and check fixed point of self-compilation
+self-self: selfie
 	./selfie -c selfie.c -o selfie1.m -s selfie1.s -m 2 -c selfie.c -o selfie2.m -s selfie2.s
 	diff -q selfie1.m selfie2.m
 	diff -q selfie1.s selfie2.s
@@ -159,7 +163,7 @@ selfie-2-x86: riscv-2-x86 selfie selfie.h selfie.m
 	diff -q selfie.x86 selfie1.x86
 
 # Run everything that only requires standard tools
-all: compile quine debug replay os vm min mob gib gclib giblib gclibtest sat mon smt mod btor2 selfie-2-x86
+all: self self-self quine debug replay os vm min mob gib gclib giblib gclibtest sat mon smt mod btor2 selfie-2-x86
 
 # Test autograder
 grader: selfie

--- a/grader/self.py
+++ b/grader/self.py
@@ -238,9 +238,8 @@ def check_fork_and_wait() -> List[Check]:
 
 
 def check_fork_wait_exit() -> List[Check]:
-    return check_compilable('sum-exit-code.c', 'fork and wait compiled') + \
-        check_mipster_execution('sum-exit-code.c', 28,
-                                'exit code is returned as status parameter from wait with MIPSTER') + \
+    return check_mipster_execution('sum-exit-code.c', 28,
+                                   'exit code is returned as status parameter from wait with MIPSTER') + \
         check_hypster_execution('sum-exit-code.c', 28,
                                 'exit code is returned as status parameter from wait with HYPSTER') + \
         check_mipster_execution('unmapped-page-wait.c', 42,

--- a/grader/self.py
+++ b/grader/self.py
@@ -32,13 +32,13 @@ REPO_BLOB_BASE_URI = 'https://github.com/cksystemsteaching/selfie/blob/master/'
 
 
 def check_self_compilation(mandatory=False) -> List[Check]:
-    return check_execution('make clean selfie', 'cc compiles selfie.c', mandatory=mandatory) + \
+    return check_execution('make self', 'selfie compiles selfie.c', mandatory=mandatory) + \
         check_compile_warnings(
             'selfie.c', 'self-compilation does not lead to warnings or syntax errors', mandatory=mandatory)
 
 
 def check_print_your_name() -> List[Check]:
-    return check_execution('./selfie -c selfie.c -m 128',
+    return check_execution('./selfie -c selfie.c -m 1',
                            'selfie prints first and second name',
                            success_criteria=lambda code, out: contains_name(out))
 


### PR DESCRIPTION
This PR introduces two small changes to the grader:

* Fixes the self-compilation target of the grader. Contrary to its name, `self-compile` does compile Selfie with the native toolchain instead of performing self-compilation. This is a cherry-pick from commit a054c81 on the `arch` branch.
* Removes the compilability check from assignment `fork-wait-exit`. @fischer-martin suggested this change because it causes the grader to emit grade `4` for little to no work based on the previous assignment, `fork-wait`