### PR TITLE
Fix segfault occuring while copying strings of specific lengths

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -2175,7 +2175,7 @@ char* string_copy(char* s) {
 
   i = 0;
 
-  while (i <= l) {
+  while (i < l) {
     store_character(t, i, load_character(s, i));
 
     i = i + 1;


### PR DESCRIPTION
While implementing our macros for variadic functions, we encountered a segfault in `copy_string` when calling with a string of size 7 (without null termination, i.e., 8 with the null), e.g., "var_arg" but not for other arguments, e.g., `var_start`.
The segfault does not happen on bootlevel 0, but valgrind reveals the invalid read and write. It does, however, always appear on bootlevel >= 1.

The termination condition repeats the loop `length + 1` times, where `length` is the length of the string without null termination, i.e., the loop also copies the null byte. After the loop we explicitly set the null byte at position `length + 2` and therefore access an invalid memory address.

This pull request fixes the bug by not copying the null byte inside the loop. Alternatively, we could also not explicitly set the null byte after the loop as it is already copied from the other string.