### PR TITLE
Grader: Do not pass `thread` checks shared-(data|heap) if unimplemented

### DIFF
--- a/grader/assignments/threads/shared-data.c
+++ b/grader/assignments/threads/shared-data.c
@@ -17,10 +17,10 @@ int main(int argc, char** argv) {
   if (tid)
     pthread_join(status);
   else {
-    global_variable = 42;
+    global_variable = 32;
 
-    pthread_exit(0);
+    pthread_exit(10);
   }
 
-  return global_variable;
+  return *status + global_variable;
 }

--- a/grader/assignments/threads/shared-heap.c
+++ b/grader/assignments/threads/shared-heap.c
@@ -18,10 +18,10 @@ int main(int argc, char** argv) {
     pthread_join(status);
   else {
     heap_variable = malloc(8);
-    *heap_variable = 42;
+    *heap_variable = 30;
 
-    pthread_exit(0);
+    pthread_exit(12);
   }
 
-  return *heap_variable;
+  return *status + *heap_variable;
 }


### PR DESCRIPTION
The checks `shared-heap` and `shared-data` erroneously passed when the
pthread syscalls were added, but not completely implemented. If the
return value of `pthread_create` happens to be 0, the main thread enters
the branch meant for the created thread, and does perform the operations
that pass the test.

This PR additionally uses the exit code to determine the check's exit
code. If the assignment has not been implemented, the test will fail due
to the missing thread's exit code.