### PR TITLE
L1-cache example programs

### DIFF
--- a/examples/cache/coherency-invalidation.c
+++ b/examples/cache/coherency-invalidation.c
@@ -1,0 +1,29 @@
+uint64_t* e_entry = (uint64_t*) 65536;
+uint64_t instructions_word_offset = 41;
+uint64_t patched_addi = 2830383514643;
+
+uint64_t get_return_value() {
+  return 1;
+}
+
+void patch_return_value() {
+  // requires write access to the code segment
+  *(e_entry + instructions_word_offset) = patched_addi;
+}
+
+uint64_t main() {
+  uint64_t return_value;
+
+  // instruction containing the return code
+  // will be loaded into the icache
+  return_value = get_return_value();
+
+  // patches get_return_value() to return 0 instead of 1
+  patch_return_value();
+
+  // returns 1 if there is no coherency between
+  // dcache and icache (correct behavior: 0)
+  return_value = get_return_value();
+
+  return return_value;
+}

--- a/examples/cache/dcache-access-0.c
+++ b/examples/cache/dcache-access-0.c
@@ -1,0 +1,62 @@
+uint64_t L1_DCACHE_SIZE = 32768;
+uint64_t PAGESIZE = 4096;
+uint64_t WORDSIZE = 8;
+
+// POSIX drand48 values
+uint64_t NUM_GEN_m = 281474976710656; // modulus
+uint64_t NUM_GEN_a = 25214903917;     // multiplier
+uint64_t NUM_GEN_c = 11;              // increment
+
+uint64_t NUM_GEN_x_n = 42424242;
+
+uint64_t generate_number() {
+  NUM_GEN_x_n = (NUM_GEN_a * NUM_GEN_x_n + NUM_GEN_c) % NUM_GEN_m;
+
+  return NUM_GEN_x_n;
+}
+
+uint64_t* malloc_and_touch_pages(uint64_t size) {
+  uint64_t* x;
+  uint64_t num_pages;
+  uint64_t i;
+
+  x = malloc(size);
+
+  if (size % PAGESIZE == 0)
+    num_pages = size / PAGESIZE;
+  else
+    num_pages = size / PAGESIZE + 1;
+
+  i = 0;
+
+  while (i < num_pages) {
+    *(x + i * PAGESIZE / WORDSIZE) = 0;
+
+    i = i + 1;
+  }
+
+  return x;
+}
+
+uint64_t main() {
+  uint64_t* x;
+  uint64_t words;
+  uint64_t i;
+
+  words = 1024 * L1_DCACHE_SIZE / WORDSIZE;
+
+  // make sure that all pages are mapped before testing access pattern
+  // in order to prevent page faults from causing cache flushes
+  x = malloc_and_touch_pages(words * WORDSIZE);
+
+  i = 0;
+
+  // test access pattern with 1_000_000 memory accesses
+  while (i < 1000000) {
+    *(x + generate_number() % words) = 42;
+
+    i = i + 1;
+  }
+
+  return 0;
+}

--- a/examples/cache/dcache-access-1.c
+++ b/examples/cache/dcache-access-1.c
@@ -1,0 +1,62 @@
+uint64_t L1_DCACHE_SIZE = 32768;
+uint64_t PAGESIZE = 4096;
+uint64_t WORDSIZE = 8;
+
+// simple counter that wraps at the modulus
+uint64_t NUM_GEN_m = 281474976710656; // modulus
+uint64_t NUM_GEN_a = 1;               // multiplier
+uint64_t NUM_GEN_c = 1;               // increment
+
+uint64_t NUM_GEN_x_n = 0;
+
+uint64_t generate_number() {
+  NUM_GEN_x_n = (NUM_GEN_a * NUM_GEN_x_n + NUM_GEN_c) % NUM_GEN_m;
+
+  return NUM_GEN_x_n;
+}
+
+uint64_t* malloc_and_touch_pages(uint64_t size) {
+  uint64_t* x;
+  uint64_t num_pages;
+  uint64_t i;
+
+  x = malloc(size);
+
+  if (size % PAGESIZE == 0)
+    num_pages = size / PAGESIZE;
+  else
+    num_pages = size / PAGESIZE + 1;
+
+  i = 0;
+
+  while (i < num_pages) {
+    *(x + i * PAGESIZE / WORDSIZE) = 0;
+
+    i = i + 1;
+  }
+
+  return x;
+}
+
+uint64_t main() {
+  uint64_t* x;
+  uint64_t words;
+  uint64_t i;
+
+  words = 1024 * L1_DCACHE_SIZE / WORDSIZE;
+
+  // make sure that all pages are mapped before testing access pattern
+  // in order to prevent page faults from causing cache flushes
+  x = malloc_and_touch_pages(words * WORDSIZE);
+
+  i = 0;
+
+  // test access pattern with 1_000_000 memory accesses
+  while (i < 1000000) {
+    *(x + generate_number() % words) = 42;
+
+    i = i + 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds the L1-cache examples from our presentation. They consist of
* `coherency-invalidation.c` for the demonstration of the hardware-enforced coherency mechanism between dcache & icache and
* `dcache-access-[01].c` for the demonstration of how different data access patterns affect the cache hit-/miss-rates.