### PR TITLE
Detect host operating system in Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
+# Give Selfie information about the operating system ($OS is defined in Windows only)
+ifeq ($(OS),Windows_NT)
+	HOSTOS := 3
+else
+	ifeq ($(shell uname -s),Darwin)
+		HOSTOS := 2
+	else ifeq ($(shell uname -s),Linux)
+		HOSTOS := 1
+	else
+		$(error operating system is not supported to build Selfie)
+	endif
+endif
+
 # Compiler flags
-CFLAGS := -Wall -Wextra -O3 -m64 -D'uint64_t=unsigned long long'
+CFLAGS := -Wall -Wextra -O3 -m64 -D'uint64_t=unsigned long long' -D'HOSTOS=$(HOSTOS)'
 
 # Bootstrap selfie.c into selfie executable
 selfie: selfie.c
 	$(CC) $(CFLAGS) $< -o $@
 
 # 32-bit compiler flags
-32-BIT-CFLAGS := -Wall -Wextra -Wno-builtin-declaration-mismatch -O3 -m32 -D'uint64_t=unsigned long'
+32-BIT-CFLAGS := -Wall -Wextra -Wno-builtin-declaration-mismatch -O3 -m32 -D'uint64_t=unsigned long' -D'HOSTOS=$(HOSTOS)'
 
 # Bootstrap selfie.c into 32-bit selfie executable, requires 32-bit compiler support
 selfie-32: selfie.c

--- a/machine/defines.mk
+++ b/machine/defines.mk
@@ -122,7 +122,7 @@ $$(TARGET_$(1)_$(2)_DIR)/%.o: %.S | $$(TARGET_$(1)_$(2)_OUT_TREE)
 	$$(AS) -c $$(ASFLAGS) $$(PROFILE_$(2)_DEFINES) $$< -o $$@
 
 $$(TARGET_$(1)_$(2)_DIR)/selfie.o: $$(SELFIE_PATH)/selfie.c
-	$$(CC) $$(CFLAGS) -Wno-return-type -D'uint64_t = unsigned long long int' -c $$^ -o $$@
+	$$(CC) $$(CFLAGS) -Wno-return-type -D'uint64_t = unsigned long long int' -D'HOSTOS=4' -c $$^ -o $$@
 
 endef
 


### PR DESCRIPTION
I had problems with Selfie on Windows 10, when compiled with Mingw64 (gcc). Selfie did not detect, that it runs on Windows, and therefore had problems to generate output files, because it used the wrong flags for `open()`.

So I figured, I should think of a more reliable way to detect, if Selfie is running on Windows. This is a more straightforward way to detect that, which could also be triggered on MacOs/Linux, if someone would use a ".exe" file extension on these platforms. But I think it is safe to say, that we probably never will see an issue with that.