### PR TITLE
Use gcc from cygwin to build on windows

### DIFF
--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -52,6 +52,22 @@ jobs:
     - name: Run autograder baseline
       run: make grade
 
+  make-all-on-windows:
+    name: Make all of selfie on Windows
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout selfie
+      uses: actions/checkout@v2
+    - name: Use gcc from cygwin
+      run: |
+        choco upgrade cygwin -y --no-progress
+        choco install gcc-core make -y --no-progress --source=cygwin
+        echo 'C:\tools\cygwin\bin' >> $env:GITHUB_PATH
+    - name: Make all
+      run: make -j -O all
+    # python3 does not work here
+
   make-everything-on-docker:
     name: Make everything of selfie on docker
     runs-on: ubuntu-latest


### PR DESCRIPTION
This installs `gcc` and `make` from Cygwin to build on Windows. I did not add a step to run the autograder baseline, but we could try whether using `python` from Cygwin works at some point.