### PR TITLE
Machine: Implement `dprintf` and `sprintf`

### DIFF
--- a/machine/filesystem.c
+++ b/machine/filesystem.c
@@ -16,3 +16,35 @@ const KFILE* find_file(const char* filename) {
   else
     return NULL;
 }
+
+bool fd_is_stdio(int fd) {
+  return (fd >= 0) && (fd <= 2);
+}
+
+bool fd_is_valid(int fd, size_t num_fds) {
+  return (fd >= 0) && (((uint32_t) fd) < num_fds + OPEN_FILE_FD_OFFSET);
+}
+
+FILEDESC* get_fd_entry(int fd, FILEDESC* open_files, size_t num_fds) {
+  if (!fd_is_valid(fd, num_fds))
+    return NULL;
+
+  // There's no FILEDESC for stdin/stdout/stderr
+  if (fd_is_stdio(fd))
+    return NULL;
+
+  return open_files + (fd - OPEN_FILE_FD_OFFSET);
+}
+
+bool fd_entry_is_opened(FILEDESC* entry) {
+  return (entry != NULL) && (entry->file != NULL);
+}
+
+bool fd_is_opened(int fd, FILEDESC* open_files, size_t num_fds) {
+  FILEDESC* entry = get_fd_entry(fd, open_files, num_fds);
+  // If an entry is NULL, fd is either invalid or an stdio special fd
+  if (entry == NULL)
+    return fd_is_stdio(fd);
+
+  return fd_entry_is_opened(entry);
+}

--- a/machine/include/diag.h
+++ b/machine/include/diag.h
@@ -3,7 +3,7 @@
 
 #include <stdarg.h>
 
-void panic(const char* diagnostic_message, ...);
+void panic(const char* diagnostic_message, ...) __attribute__((noreturn));
 void shutdown() __attribute__((noreturn));
 
 extern void hang_machine() __attribute__((noreturn));

--- a/machine/include/filesystem.h
+++ b/machine/include/filesystem.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 
 typedef struct KFILE {
@@ -19,5 +20,14 @@ typedef struct FILEDESC {
 extern const KFILE files[];
 
 const KFILE* find_file(const char* filename);
+
+// File descriptor util functions
+bool fd_is_stdio(int fd);
+bool fd_is_valid(int fd, size_t num_fds);
+FILEDESC* get_fd_entry(int fd, FILEDESC* open_files, size_t num_fds);
+bool fd_entry_is_opened(FILEDESC* entry);
+bool fd_is_opened(int fd, FILEDESC* open_files, size_t num_fds);
+
+#define OPEN_FILE_FD_OFFSET 3
 
 #endif /* SBI_FILES_BASE */

--- a/machine/include/tinycstd.h
+++ b/machine/include/tinycstd.h
@@ -24,6 +24,9 @@ int printf(const char* format, ...);
 void puts(const char* s);
 void putc(char c);
 
+// POSIX.1-2008
+int dprintf(int fd, const char* format, ...);
+
 int va_printf(const char* format, va_list args);
 
 #endif /* KERN_TINYCSTD */

--- a/machine/include/tinycstd.h
+++ b/machine/include/tinycstd.h
@@ -21,6 +21,7 @@ size_t strlcpy(char* dest, const char* src, size_t n);
 
 // <stdio.h> I/O functions
 int printf(const char* format, ...);
+int sprintf(char* str, const char* format, ...);
 void puts(const char* s);
 void putc(char c);
 

--- a/machine/syscalls.c
+++ b/machine/syscalls.c
@@ -5,41 +5,6 @@
 
 #include "compiler-utils.h"
 
-#define OPEN_FILE_FD_OFFSET 3
-
-bool fd_is_stdio(int fd) {
-  return (fd >= 0) && (fd <= 2);
-}
-
-bool fd_is_valid(int fd, size_t num_fds) {
-  return (fd >= 0) && (((uint32_t) fd) < num_fds + OPEN_FILE_FD_OFFSET);
-}
-
-FILEDESC* get_fd_entry(int fd, FILEDESC* open_files, size_t num_fds) {
-  if (!fd_is_valid(fd, num_fds))
-    return NULL;
-
-  // There's no FILEDESC for stdin/stdout/stderr
-  if (fd_is_stdio(fd))
-    return NULL;
-
-  return open_files + (fd - OPEN_FILE_FD_OFFSET);
-}
-
-bool fd_entry_is_opened(FILEDESC* entry) {
-  return (entry != NULL) && (entry->file != NULL);
-}
-
-bool fd_is_opened(int fd, FILEDESC* open_files, size_t num_fds) {
-  FILEDESC* entry = get_fd_entry(fd, open_files, num_fds);
-  // If an entry is NULL, fd is either invalid or an stdio special fd
-  if (entry == NULL)
-    return fd_is_stdio(fd);
-
-  return fd_entry_is_opened(entry);
-}
-
-
 ssize_t kread(int fd, char* buf, size_t nbytes, FILEDESC* open_files, size_t num_fds) {
   if (!fd_is_valid(fd, num_fds))
     return -1;

--- a/machine/tinycstd.c
+++ b/machine/tinycstd.c
@@ -4,6 +4,7 @@
 #include "diag.h"
 #include "syscalls.h"
 #include "compiler-utils.h"
+#include <stdarg.h>
 
 // Format string handling
 typedef ssize_t (*put_handler)(const char* buffer, ssize_t len, void** context);
@@ -113,6 +114,22 @@ int printf(const char* format, ...) {
   va_end(args);
 
   return result;
+}
+
+ssize_t sprintf_put(const char* str, ssize_t len, void** ctxt) {
+  strlcpy((*ctxt)+1, str, len+1); // len+1 due to \0
+  return len;
+}
+int sprintf(char* buf, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+
+  int ret = handle_format_string(format, args, sprintf_put, buf);
+  // No need for explicitly setting \0 at the end - strlcpy in sprintf_put already does the job
+
+  va_end(args);
+
+  return ret;
 }
 
 void puts(const char* s) {

--- a/machine/tinycstd.c
+++ b/machine/tinycstd.c
@@ -2,7 +2,9 @@
 
 #include <stdarg.h>
 #include <stdint.h>
+
 #include "console.h"
+#include "diag.h"
 #include "syscalls.h"
 
 // Function required by libgcc for a freestanding environment
@@ -109,6 +111,21 @@ int printf(const char* format, ...) {
   va_end(args);
 
   return result;
+}
+
+int dprintf(int fd, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  int ret;
+
+  if (fd_is_stdio(fd))
+    ret = va_printf(format, args);
+  else
+    panic("dprintf called with non-stdio descriptor (no write support on files)");
+
+  va_end(args);
+
+  return ret;
 }
 
 int va_printf(const char* format, va_list args) {

--- a/machine/tinycstd.c
+++ b/machine/tinycstd.c
@@ -113,6 +113,14 @@ int printf(const char* format, ...) {
   return result;
 }
 
+void puts(const char* s) {
+  console_puts(s, strlen(s));
+}
+
+void putc(char c) {
+  console_putc(c);
+}
+
 int dprintf(int fd, const char* format, ...) {
   va_list args;
   va_start(args, format);
@@ -215,14 +223,6 @@ int va_printf(const char* format, va_list args) {
       }
     }
   }
-}
-
-void puts(const char* s) {
-  console_puts(s, strlen(s));
-}
-
-void putc(char c) {
-  console_putc(c);
 }
 
 


### PR DESCRIPTION
This commit introduces functions `dprintf` and `sprintf` to the kernel's tiny C library. This is required because the `printf` branch introduces dependencies on aforementioned functions as well as `printf`, which has partially been implemented for use by the kernels already.
As the kernels build in a freestanding environment, no C standard library is provided to us and we must provide relevant functions ourselves.

This commit does only fix compilation failures, but does not yet implement relevant format string flags.