### PR TITLE
Refine hex-literal assignment definition [skip ci]

### DIFF
--- a/assignments/compiler-assignments.md
+++ b/assignments/compiler-assignments.md
@@ -38,7 +38,8 @@ So instead of printing:
 
 Implement support of hexadecimal integer literals.
 
-- Do not modify any files other than **selfie.c**.
+- Before coding, extend the C\* grammar with hexadecimal integer literals.
+- Do not modify any files other than **grammar.md** and **selfie.c**.
 - Use the `hex-literal` target in the grader to determine your grade.
 
 


### PR DESCRIPTION
Add the instruction to also extend the grammar.