### PR TITLE
Update grader to show executed commands at all times

### DIFF
--- a/grader/lib/checks.py
+++ b/grader/lib/checks.py
@@ -9,7 +9,7 @@ from .model import Check, CheckResult
 from .output_processing import (filter_status_messages, has_compiled,
                                 has_no_compile_warnings, has_no_bootstrapping_compile_warnings, 
                                 is_interleaved_output, is_permutation_of)
-from .print import print_processing, print_warning, stop_processing_spinner
+from .print import print_processing, print_warning, stop_processing_spinner, print_command
 from .system import INSTRUCTIONSIZE, WORDSIZE, read_data, read_instruction
 
 if sys.version_info < (3, 3):
@@ -111,10 +111,10 @@ def execute(command, timeout=60):
 def check_instruction_encoding(instruction, file) -> List[Check]:
     msg = instruction[0] + ' has right RISC-V encoding'
 
-    def execute_check() -> CheckResult:
-        command = './selfie -c <assignment>{} -o .tmp.bin'.format(file)
-        command = insert_assignment_path(command)
+    command = './selfie -c <assignment>{} -o .tmp.bin'.format(file)
+    command = insert_assignment_path(command)
 
+    def execute_check() -> CheckResult:
         try:
             exit_code, output = execute(command)
 
@@ -166,16 +166,16 @@ def check_instruction_encoding(instruction, file) -> List[Check]:
             return CheckResult(False, msg, str(e), 'Failed to execute "{}"'.format(
                 command), True, command, mandatory=False)
 
-    return [Check(msg, execute_check)]
+    return [Check(msg, command, execute_check)]
 
 
 def check_assembler_instruction_format(instruction, file) -> List[Check]:
     msg = instruction[0] + ' RISC-V instruction has right assembly instruction format'
 
-    def execute_check() -> CheckResult:
-        command = './selfie -c <assignment>{} -s .tmp.s'.format(file)
-        command = insert_assignment_path(command)
+    command = './selfie -c <assignment>{} -s .tmp.s'.format(file)
+    command = insert_assignment_path(command)
 
+    def execute_check() -> CheckResult:
         try:
             exit_code, output = execute(command)
 
@@ -206,13 +206,13 @@ def check_assembler_instruction_format(instruction, file) -> List[Check]:
             return CheckResult(False, msg, str(e), 'Failed to execute "{}"'.format(
                 command), True, command, mandatory=False)
 
-    return [Check(msg, execute_check)]
+    return [Check(msg, command, execute_check)]
 
 
 def check_execution(command, msg, success_criteria=True, should_succeed=True, mandatory=False, timeout=60) -> List[Check]:
-    def execute_check() -> CheckResult:
-        secure_command = insert_assignment_path(command)
+    secure_command = insert_assignment_path(command)
 
+    def execute_check() -> CheckResult:
         try:
             returncode, output = execute(secure_command, timeout)
 
@@ -253,7 +253,7 @@ def check_execution(command, msg, success_criteria=True, should_succeed=True, ma
             return CheckResult(False, msg, str(e), 'Failed to execute "{}"'.format(
                 secure_command), should_succeed, secure_command, mandatory)
 
-    return [Check(msg, execute_check)]
+    return [Check(msg, secure_command, execute_check)]
 
 
 def check_compilable(file, msg, should_succeed=True) -> List[Check]:

--- a/grader/lib/checks.py
+++ b/grader/lib/checks.py
@@ -9,7 +9,7 @@ from .model import Check, CheckResult
 from .output_processing import (filter_status_messages, has_compiled,
                                 has_no_compile_warnings, has_no_bootstrapping_compile_warnings, 
                                 is_interleaved_output, is_permutation_of)
-from .print import print_processing, print_warning, stop_processing_spinner, print_command
+from .print import print_processing, print_warning, stop_processing_spinner
 from .system import INSTRUCTIONSIZE, WORDSIZE, read_data, read_instruction
 
 if sys.version_info < (3, 3):

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -13,7 +13,7 @@ from lib.grade import grade
 from lib.checks import set_home_path, set_assignment_name
 from lib.print import (enter_quiet_mode, leave_quiet_mode, print_error,
                        print_message, print_warning, print_grade, print_processing,
-                       stop_processing_spinner, print_passed, print_failed,
+                       stop_processing_spinner, print_passed, print_failed, print_command,
                        reset_truncate, set_truncate)
 
 DEFAULT_BULK_GRADE_DIRECTORY = os.path.abspath('./.repositories')
@@ -85,6 +85,9 @@ def validate_options_for(assignment: Optional[Assignment]):
 
 
 def execute_with_output(check: Check) -> CheckResult:
+    if check.command:
+        print_command(check.command)
+
     print_processing(check.msg)
 
     try:

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -13,7 +13,7 @@ from lib.grade import grade
 from lib.checks import set_home_path, set_assignment_name
 from lib.print import (enter_quiet_mode, leave_quiet_mode, print_error,
                        print_message, print_warning, print_grade, print_processing,
-                       stop_processing_spinner, print_passed, print_failed, print_command,
+                       stop_processing_spinner, print_passed, print_failed,
                        reset_truncate, set_truncate)
 
 DEFAULT_BULK_GRADE_DIRECTORY = os.path.abspath('./.repositories')
@@ -85,10 +85,7 @@ def validate_options_for(assignment: Optional[Assignment]):
 
 
 def execute_with_output(check: Check) -> CheckResult:
-    if check.command:
-        print_command(check.command)
-
-    print_processing(check.msg)
+    print_processing(check.msg, check.command)
 
     try:
         result = check.execute()

--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -93,7 +93,7 @@ def execute_with_output(check: Check) -> CheckResult:
         stop_processing_spinner()
 
     if result.result == result.should_succeed:
-        print_passed(check.msg)
+        print_passed(check.msg, result.command)
     else:
         print_failed(check.msg, result.warning, result.output, result.command)
 

--- a/grader/lib/model.py
+++ b/grader/lib/model.py
@@ -14,6 +14,7 @@ class CheckResult:
 @dataclass(frozen=True)
 class Check:
     msg: str
+    command: str
     execute: Callable[[], CheckResult]
 
 @dataclass(frozen=True)

--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -35,14 +35,10 @@ def print_grade(grade):
 
 def print_passed(msg, command):
     println("\033[92m[PASSED]\033[0m " + msg)
-    if command != None:
-        print_command(command)
 
 
 def print_failed(msg, warning, output: str, command):
     println("\033[91m[FAILED]\033[0m " + msg)
-    if command != None:
-        print_command(command)
     if warning != None:
         println("\033[93m > " + warning + " <\033[0m")
 

--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -61,10 +61,6 @@ def print_failed(msg, warning, output: str, command):
     println(' >> ' + output[:-1].replace('\n', '\n >> '))
 
 
-def print_command(command):
-    println("\033[33m" + command + "\033[0m")
-
-
 def print_message(message, end='\n', loud=False):
     println(message, end=end, loud=loud)
 
@@ -105,8 +101,11 @@ class SpinnerThread(threading.Thread):
 spinner_thread = None
 
 
-def print_processing(msg):
+def print_processing(msg, command=''):
     global spinner_thread
+
+    if command:
+        msg = msg + ": \033[33m$ " + command + "\033[0m"
 
     spinner_thread = SpinnerThread(msg)
     spinner_thread.daemon = True  # die when parent dies

--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -33,14 +33,16 @@ def print_grade(grade):
     println('\033[0m')
 
 
-def print_passed(msg):
+def print_passed(msg, command):
     println("\033[92m[PASSED]\033[0m " + msg)
+    if command != None:
+        print_command(command)
 
 
 def print_failed(msg, warning, output: str, command):
     println("\033[91m[FAILED]\033[0m " + msg)
     if command != None:
-        println(command)
+        print_command(command)
     if warning != None:
         println("\033[93m > " + warning + " <\033[0m")
 
@@ -61,6 +63,10 @@ def print_failed(msg, warning, output: str, command):
 
 
     println(' >> ' + output[:-1].replace('\n', '\n >> '))
+
+
+def print_command(command):
+    println("\033[33m" + command + "\033[0m")
 
 
 def print_message(message, end='\n', loud=False):

--- a/grader/tests/test_cli.py
+++ b/grader/tests/test_cli.py
@@ -45,7 +45,7 @@ class TestCli(unittest.TestCase):
 
             return CheckResult(True, '', '', '')
 
-        return [Check('', lambda: assert_order(n_th_baseline))]
+        return [Check('', '', lambda: assert_order(n_th_baseline))]
 
     def check_assignment_mock(self) -> List[Check]:
         def assert_executed_after_baseline() -> CheckResult:
@@ -53,7 +53,7 @@ class TestCli(unittest.TestCase):
 
             return CheckResult(True, '', '', '')
 
-        return [Check('', assert_executed_after_baseline)]
+        return [Check('', '', assert_executed_after_baseline)]
 
     def test_baseline_execution_order(self):
         with CaptureOutput():

--- a/grader/tests/test_compilable.py
+++ b/grader/tests/test_compilable.py
@@ -29,7 +29,7 @@ class TestCompilable(unittest.TestCase):
                                  'compiling ' + file + ' with gcc leads to no error')
             return CheckResult(True, "unittest", "", "")
 
-        return [Check("compilable_check_mock", execute)]
+        return [Check("compilable_check_mock", "", execute)]
 
     def save_assignment(self, assignment):
         self.assignment = assignment.category

--- a/grader/tests/test_execution.py
+++ b/grader/tests/test_execution.py
@@ -41,7 +41,7 @@ class TestExecution(TestCase):
 
             return CheckResult(True, "", "", "")
         
-        return [Check("execution_mock", execution)]
+        return [Check("execution_mock", "", execution)]
 
 
     @patch('self.check_mipster_execution')


### PR DESCRIPTION
As suggested in the lecture, someone (me) made the grader spit out what it is executing.
It was already doing that for failed tests, now it does it all the time. Also colored in yellow/orange/gold.

![picture](https://user-images.githubusercontent.com/41904979/115621254-8ad80700-a2f6-11eb-88fa-46a74ae544d7.png)

(ignore the lines above the first [PASSED], its my own script I use so I do not have to remember exact assignment identifiers)