### PR TITLE
Bug with grader

### DIFF
--- a/grader/lib/print.py
+++ b/grader/lib/print.py
@@ -34,10 +34,14 @@ def print_grade(grade):
 
 
 def print_passed(msg, command):
+    if command:
+        msg = msg + ": \033[33m$ " + command + "\033[0m"
     println("\033[92m[PASSED]\033[0m " + msg)
 
 
 def print_failed(msg, warning, output: str, command):
+    if command:
+        msg = msg + ": \033[33m$ " + command + "\033[0m"
     println("\033[91m[FAILED]\033[0m " + msg)
     if warning != None:
         println("\033[93m > " + warning + " <\033[0m")


### PR DESCRIPTION
Hi,
after doing the current assignment, I tested the grader and found a bug. Basically, whenever the processing spinner prints out a line that is too large for the width of the window, it is not properly removed in the end.
Originally, I found this in the unchanged grader (before you merged my PR). But this is obviously still the case with the merged changes (tested it, see image below). Not only that, adding commands amplifies the problem, as all lines are now significantly larger.

![picture](https://user-images.githubusercontent.com/41904979/116975749-63067d00-acc0-11eb-9218-9a4f5510fd3b.png)

As you can see, the first FAILED test still has the processing timer above it, the others do not.

This PR currently contains changes to improve the current way commands are printed (same line), but I offer to change it back to printing commands before (above) the processing counter, as you auggested originally @ckirsch 
I would just add a bunch of commits to this PR and let you know when everything is good to go. The bug would still be there, but not noticable using default or larger window size.
