### PR TITLE
Grader: Fix ELF program header code start/length parsing (closes #277)

### DIFF
--- a/grader/lib/checks.py
+++ b/grader/lib/checks.py
@@ -138,19 +138,14 @@ def check_instruction_encoding(instruction, file) -> List[Check]:
                         # and p_paddr are located
                         ignored_elf_pheader_seek = 2 * WORDSIZE
 
-                        f.read(ignored_elf_header_size)
+                        f.seek(ignored_elf_header_size)
 
                         code_start = read_data(f)
                         f.read(ignored_elf_pheader_seek)
                         code_length = read_data(f)
 
                         # ignore all pading bytes
-                        no_of_bytes_until_code = code_start - ignored_elf_header_size - ignored_elf_pheader_seek - 2 * WORDSIZE
-
-                        if no_of_bytes_until_code < 0:
-                            no_of_bytes_until_code = 0
-
-                        f.read(no_of_bytes_until_code)
+                        f.seek(code_start)
 
                         # read all RISC-V instructions from binary
                         read_instructions = map(lambda x: read_instruction(


### PR DESCRIPTION
Somewhere around commit 0bd8da6, Selfie changed the way the ELF header
is emitted. Instead of a combined section, there are two separate
sections, one for code and one for data. By changing the header, the
grader did read the code start/length from the wrong location.

As before, the field parsing is hardwired to Selfie's output to keep
complexity minimal (otherwise we would require a full-fledged ELF
parser)

There's one caveat, though: Selfie now supports 32-bit as well. However,
the grader is not able to parse ELF32 binaries as of now because the
length of Elf64_Off/Elf64_Addr and Elf32_Off/Elf32_Addr differ.