### PR TITLE
Machine: Move RISC-U binary artifacts to build directory (closes #287)

### DIFF
--- a/machine/Makefile
+++ b/machine/Makefile
@@ -31,6 +31,12 @@ include defines.mk
 include filesystem.mk
 
 # ==============================================================================
+# Add rules for packaged RISC-U binaries
+
+$(eval $(call compile_riscu_binary,$(SELFIE_PATH)/selfie.c,$(BUILD_DIR)/selfie.m))
+$(eval $(call compile_riscu_binary,$(SELFIE_PATH)/examples/hello-world.c,$(BUILD_DIR)/hello-world.m))
+
+# ==============================================================================
 
 #selfie-k210.bin: selfie-k210.elf
 #	$(OBJCOPY) -S -O binary --file-alignment 4096 --gap-fill 0xFF $^ $@

--- a/machine/Makefile
+++ b/machine/Makefile
@@ -61,7 +61,7 @@ include/asm_offsets.h: $(ASM_STRUCT_HEADERS)
 .PHONY: clean
 clean: clean-fs-package
 	@case "`realpath $(BUILD_DIR)`" in \
-		"`realpath $$PWD`/"*) rm -rf $(BUILD_DIR);;\
+		"`realpath $$PWD`/"*) rm -rf $(BUILD_DIR); echo "Removed output directory \"$(BUILD_DIR)\"...";;\
 		*) echo "WARNING: Build directory '$(BUILD_DIR)' has not been removed as it is not a descending directory";;\
 	esac
 

--- a/machine/Makefile
+++ b/machine/Makefile
@@ -24,7 +24,7 @@ SBI_WRAPPER_SRCS_COMMON = bootstrap.c tinycstd.c console.c filesystem.c files_pa
 SBI_WRAPPER_SRCS_LIBRARY = bootstrap_library.c selfie.c glue_libraryos.c asm/mem.S
 SBI_WRAPPER_SRCS_KERNEL =  bootstrap_kernel.c mmu.c context.c trap.c elf.c asm/trap.S
 
-SBI_WRAPPER_FILES_PACKAGE = $(SELFIE_PATH)/selfie.m $(SELFIE_PATH)/selfie.c $(SELFIE_PATH)/examples/hello-world.c $(SELFIE_PATH)/hello-world.m
+SBI_WRAPPER_FILES_PACKAGE = $(BUILD_DIR)/selfie.m $(SELFIE_PATH)/selfie.c $(SELFIE_PATH)/examples/hello-world.c $(BUILD_DIR)/hello-world.m
 ASM_STRUCT_HEADERS = include/context.h
 
 include defines.mk

--- a/machine/defines.mk
+++ b/machine/defines.mk
@@ -185,3 +185,20 @@ endef
 define target-build-dir
 $$(BUILD_DIR)/$(1)/$(2)
 endef
+
+
+###############################################################################
+# $(eval $(call compile_riscu_binary,srcs,out))
+#
+# Creates a new (explicit) make rule to compile source files to a RISC-U binary.
+# The output file shall be placed in the build directory $(BUILD_DIR) so that
+# all build artifacts can be cleaned
+# - srcs          : The sources to compile
+# - out           : The path of the target binary
+define compile_riscu_binary
+$(2): $(1) | $$(SELFIE_PATH)/selfie
+	$$(SELFIE_PATH)/selfie -c $$^ -o $$@
+endef
+
+$(SELFIE_PATH)/selfie: $(SELFIE_PATH)/selfie.c
+	$(MAKE) -C$(SELFIE_PATH)

--- a/machine/filesystem.mk
+++ b/machine/filesystem.mk
@@ -24,10 +24,11 @@ files_package.c: $(SBI_WRAPPER_FILES_PACKAGE)
 	@echo "  {\"\", (const char*) NULL, 0}," >>$@;
 	@echo "};" >>$@;
 
-$(SELFIE_PATH)/selfie.m: $(SELFIE_PATH)/selfie.c
-	$(MAKE) -C$(SELFIE_PATH) selfie.m
+$(BUILD_DIR)/selfie.m: $(SELFIE_PATH)/selfie.c
+	$(MAKE) -C$(SELFIE_PATH)
+	$(SELFIE_PATH)/selfie -c $^ -o $@
 
-$(SELFIE_PATH)/hello-world.m: $(SELFIE_PATH)/examples/hello-world.c
+$(BUILD_DIR)/hello-world.m: $(SELFIE_PATH)/examples/hello-world.c
 	$(MAKE) -C$(SELFIE_PATH)
 	$(SELFIE_PATH)/selfie -c $^ -o $@
 

--- a/machine/filesystem.mk
+++ b/machine/filesystem.mk
@@ -24,14 +24,6 @@ files_package.c: $(SBI_WRAPPER_FILES_PACKAGE)
 	@echo "  {\"\", (const char*) NULL, 0}," >>$@;
 	@echo "};" >>$@;
 
-$(BUILD_DIR)/selfie.m: $(SELFIE_PATH)/selfie.c
-	$(MAKE) -C$(SELFIE_PATH)
-	$(SELFIE_PATH)/selfie -c $^ -o $@
-
-$(BUILD_DIR)/hello-world.m: $(SELFIE_PATH)/examples/hello-world.c
-	$(MAKE) -C$(SELFIE_PATH)
-	$(SELFIE_PATH)/selfie -c $^ -o $@
-
 .PHONY: clean-fs-package
 clean-fs-package:
 	rm -f files_package.c


### PR DESCRIPTION
Instead of populating the repository root while performing a machine build, place the RISC-U binaries that are packaged into machine's build directory.