### PR TITLE
Implement break & continue

### DIFF
--- a/examples/break.c
+++ b/examples/break.c
@@ -1,0 +1,37 @@
+uint64_t x;
+
+uint64_t main() {
+  x = 32;
+
+  while (1) {
+    x = x + 2;
+
+    break;
+
+    x = x + 100;
+  }
+
+  while (1) {
+    while (1) {
+      x = x + 3;
+
+      break;
+
+      x = x + 100;
+    }
+
+    x = x + 5;
+
+    break;
+
+    x = x + 100;
+  }
+
+  while (1) {
+    break;
+
+    x = x + 100;
+  }
+
+  return x; // 42
+}

--- a/examples/continue.c
+++ b/examples/continue.c
@@ -1,0 +1,31 @@
+uint64_t x;
+
+uint64_t main() {
+  x = 32;
+
+  while (x == 32) {
+    x = x + 2;
+
+    continue;
+
+    x = x + 100;
+  }
+
+  while (x < 42) {
+    while (x < 40) {
+      x = x + 1;
+
+      continue;
+
+      x = x + 100;
+    }
+
+    x = x + 1;
+
+    continue;
+
+    x = x + 100;
+  }
+
+  return x; // 42
+}

--- a/grammar.md
+++ b/grammar.md
@@ -6,9 +6,9 @@ http://selfie.cs.uni-salzburg.at
 
 This is the grammar of the C Star (C\*) programming language.
 
-C\* is a tiny subset of the programming language C. C\* features global variable declarations with optional initialization as well as procedures with parameters and local variables. C\* has five statements (assignment, while loop, if-then-else, procedure call, and return) and standard arithmetic (`+`, `-`, `*`, `/`, `%`) and comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) operators. C\* includes the unary `*` operator for dereferencing pointers hence the name but excludes data types other than `uint64_t` and `uint64_t*`, bitwise and Boolean operators, and many other features. The C\* grammar is LL(1) with 6 keywords and 22 symbols. Whitespace as well as single-line (`//`) and multi-line (`/*` to `*/`) comments are ignored.
+C\* is a tiny subset of the programming language C. C\* features global variable declarations with optional initialization as well as procedures with parameters and local variables. C\* has five statements (assignment, while loop, if-then-else, procedure call, and return) and standard arithmetic (`+`, `-`, `*`, `/`, `%`) and comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) operators. C\* includes the unary `*` operator for dereferencing pointers hence the name but excludes data types other than `uint64_t` and `uint64_t*`, bitwise and Boolean operators, and many other features. The C\* grammar is LL(1) with 8 keywords and 22 symbols. Whitespace as well as single-line (`//`) and multi-line (`/*` to `*/`) comments are ignored.
 
-C\* Keywords: `uint64_t`, `void`, `if`, `else`, `while`, `return`
+C\* Keywords: `uint64_t`, `void`, `if`, `else`, `while`, `return`, `break`, `continue`
 
 C\* Symbols: `integer_literal`, `character_literal`, `string_literal`, `identifier`, `,`, `;`, `(`, `)`, `{`, `}`, `+`, `-`, `*`, `/`, `%`, `=`, `==`, `!=`, `<`, `<=`, `>`, `>=`
 
@@ -65,7 +65,7 @@ factor            = [ cast ] [ "-" ] [ "*" ]
                       identifier | call | "(" expression ")" ) .
 
 while             = "while" "(" expression ")"
-                      ( statement | "{" { statement } "}" ) .
+                      ( ( statement | "break" ";" | "continue" ";" ) | "{" { statement | "break" ";" | "continue" ";" } "}" ) .
 
 if                = "if" "(" expression ")"
                       ( statement | "{" { statement } "}" )

--- a/selfie.c
+++ b/selfie.c
@@ -397,31 +397,33 @@ uint64_t SYM_ELSE         = 6;  // else
 uint64_t SYM_VOID         = 7;  // void
 uint64_t SYM_RETURN       = 8;  // return
 uint64_t SYM_WHILE        = 9;  // while
-uint64_t SYM_COMMA        = 10; // ,
-uint64_t SYM_SEMICOLON    = 11; // ;
-uint64_t SYM_LPARENTHESIS = 12; // (
-uint64_t SYM_RPARENTHESIS = 13; // )
-uint64_t SYM_LBRACE       = 14; // {
-uint64_t SYM_RBRACE       = 15; // }
-uint64_t SYM_PLUS         = 16; // +
-uint64_t SYM_MINUS        = 17; // -
-uint64_t SYM_ASTERISK     = 18; // *
-uint64_t SYM_DIVISION     = 19; // /
-uint64_t SYM_REMAINDER    = 20; // %
-uint64_t SYM_ASSIGN       = 21; // =
-uint64_t SYM_EQUALITY     = 22; // ==
-uint64_t SYM_NOTEQ        = 23; // !=
-uint64_t SYM_LT           = 24; // <
-uint64_t SYM_LEQ          = 25; // <=
-uint64_t SYM_GT           = 26; // >
-uint64_t SYM_GEQ          = 27; // >=
+uint64_t SYM_BREAK        = 10; // break
+uint64_t SYM_CONTINUE     = 11; // continue
+uint64_t SYM_COMMA        = 12; // ,
+uint64_t SYM_SEMICOLON    = 13; // ;
+uint64_t SYM_LPARENTHESIS = 14; // (
+uint64_t SYM_RPARENTHESIS = 15; // )
+uint64_t SYM_LBRACE       = 16; // {
+uint64_t SYM_RBRACE       = 17; // }
+uint64_t SYM_PLUS         = 18; // +
+uint64_t SYM_MINUS        = 19; // -
+uint64_t SYM_ASTERISK     = 20; // *
+uint64_t SYM_DIVISION     = 21; // /
+uint64_t SYM_REMAINDER    = 22; // %
+uint64_t SYM_ASSIGN       = 23; // =
+uint64_t SYM_EQUALITY     = 24; // ==
+uint64_t SYM_NOTEQ        = 25; // !=
+uint64_t SYM_LT           = 26; // <
+uint64_t SYM_LEQ          = 27; // <=
+uint64_t SYM_GT           = 28; // >
+uint64_t SYM_GEQ          = 29; // >=
 
 // symbols for bootstrapping
 
-uint64_t SYM_INT      = 28; // int
-uint64_t SYM_CHAR     = 29; // char
-uint64_t SYM_UNSIGNED = 30; // unsigned
-uint64_t SYM_ELLIPSIS = 31; // ...
+uint64_t SYM_INT      = 30; // int
+uint64_t SYM_CHAR     = 31; // char
+uint64_t SYM_UNSIGNED = 32; // unsigned
+uint64_t SYM_ELLIPSIS = 33; // ...
 
 uint64_t* SYMBOLS; // strings representing symbols
 
@@ -471,6 +473,8 @@ void init_scanner () {
   *(SYMBOLS + SYM_VOID)         = (uint64_t) "void";
   *(SYMBOLS + SYM_RETURN)       = (uint64_t) "return";
   *(SYMBOLS + SYM_WHILE)        = (uint64_t) "while";
+  *(SYMBOLS + SYM_BREAK)        = (uint64_t) "break";
+  *(SYMBOLS + SYM_CONTINUE)     = (uint64_t) "continue";
   *(SYMBOLS + SYM_COMMA)        = (uint64_t) ",";
   *(SYMBOLS + SYM_SEMICOLON)    = (uint64_t) ";";
   *(SYMBOLS + SYM_LPARENTHESIS) = (uint64_t) "(";
@@ -665,6 +669,8 @@ uint64_t compile_expression();
 void     compile_while();
 void     compile_if();
 void     compile_return();
+void     compile_break();
+void     compile_continue();
 void     compile_statement();
 uint64_t compile_type();
 void     compile_variable(uint64_t offset);
@@ -678,6 +684,12 @@ uint64_t allocated_temporaries = 0; // number of allocated temporaries
 
 uint64_t return_branches = 0; // fixup chain for return statements
 
+uint64_t break_branches = 0; // fixup chain for break statements
+
+uint64_t continue_branches = 0; // fixup chain for continue statements
+
+uint64_t loop_dim = 0; // 0: currently not inside a loop | 1: inside a while loop | 2: inside a while loop which is inside a while loop etc.
+
 uint64_t return_type = 0; // return type of currently parsed procedure
 
 uint64_t number_of_calls       = 0;
@@ -685,6 +697,8 @@ uint64_t number_of_assignments = 0;
 uint64_t number_of_while       = 0;
 uint64_t number_of_if          = 0;
 uint64_t number_of_return      = 0;
+uint64_t number_of_break       = 0;
+uint64_t number_of_continue    = 0;
 
 // ------------------------- INITIALIZATION ------------------------
 
@@ -694,6 +708,8 @@ void reset_parser() {
   number_of_while       = 0;
   number_of_if          = 0;
   number_of_return      = 0;
+  number_of_break       = 0;
+  number_of_continue    = 0;
 
   number_of_syntax_errors = 0;
 
@@ -3462,6 +3478,10 @@ uint64_t identifier_or_keyword() {
     return SYM_RETURN;
   else if (identifier_string_match(SYM_WHILE))
     return SYM_WHILE;
+  else if (identifier_string_match(SYM_BREAK))
+    return SYM_BREAK;
+  else if (identifier_string_match(SYM_CONTINUE))
+    return SYM_CONTINUE;
   else if (identifier_string_match(SYM_INT))
     // selfie bootstraps int to uint64_t!
     return SYM_UINT64;
@@ -4010,6 +4030,10 @@ uint64_t look_for_statement() {
   else if (symbol == SYM_IF)
     return 0;
   else if (symbol == SYM_RETURN)
+    return 0;
+  else if (symbol == SYM_BREAK)
+    return 0;
+  else if (symbol == SYM_CONTINUE)
     return 0;
   else if (symbol == SYM_EOF)
     return 0;
@@ -4813,8 +4837,20 @@ uint64_t compile_expression() {
 }
 
 void compile_while() {
+  uint64_t outside_break_branches;
+  uint64_t outside_continue_branches;
   uint64_t jump_back_to_while;
   uint64_t branch_forward_to_end;
+
+  loop_dim = loop_dim + 1;
+
+  outside_break_branches = break_branches;
+
+  outside_continue_branches = continue_branches;
+
+  break_branches = 0;
+
+  continue_branches = 0;
 
   // assert: allocated_temporaries == 0
 
@@ -4875,9 +4911,19 @@ void compile_while() {
     // now we have the address for the conditional branch from above
     fixup_relative_BFormat(branch_forward_to_end);
 
+  fixlink_relative(break_branches, code_size);
+
+  fixlink_relative(continue_branches, jump_back_to_while);
+
   // assert: allocated_temporaries == 0
 
   number_of_while = number_of_while + 1;
+
+  loop_dim = loop_dim - 1;
+
+  break_branches = outside_break_branches;
+
+  continue_branches = outside_continue_branches;
 }
 
 void compile_if() {
@@ -5005,6 +5051,60 @@ void compile_return() {
   // assert: allocated_temporaries == 0
 
   number_of_return = number_of_return + 1;
+}
+
+void compile_break() {
+  // assert: allocated_temporaries == 0
+
+  if (symbol == SYM_BREAK)
+    get_symbol();
+  else
+    syntax_error_symbol(SYM_BREAK);
+
+  if (loop_dim > 0) {
+    // jump to procedure epilogue through fixup chain using absolute address
+    emit_jal(REG_ZR, break_branches);
+
+    // new head of fixup chain
+    break_branches = code_size - INSTRUCTIONSIZE;
+  } else
+    syntax_error_message("break statement outside of loop");
+
+  if (symbol == SYM_SEMICOLON)
+    get_symbol();
+  else
+    syntax_error_symbol(SYM_SEMICOLON);
+
+  // assert: allocated_temporaries == 0
+
+  number_of_break = number_of_break + 1;
+}
+
+void compile_continue() {
+  // assert: allocated_temporaries == 0
+
+  if (symbol == SYM_CONTINUE)
+    get_symbol();
+  else
+    syntax_error_symbol(SYM_CONTINUE);
+
+  if (loop_dim > 0) {
+    // jump to procedure epilogue through fixup chain using absolute address
+    emit_jal(REG_ZR, continue_branches);
+
+    // new head of fixup chain
+    continue_branches = code_size - INSTRUCTIONSIZE;
+  } else
+    syntax_error_message("continue statement outside of loop");
+
+  if (symbol == SYM_SEMICOLON)
+    get_symbol();
+  else
+    syntax_error_symbol(SYM_SEMICOLON);
+
+  // assert: allocated_temporaries == 0
+
+  number_of_continue = number_of_continue + 1;
 }
 
 void compile_statement() {
@@ -5177,6 +5277,14 @@ void compile_statement() {
       get_symbol();
     else
       syntax_error_symbol(SYM_SEMICOLON);
+  }
+  // break statement?
+  else if (symbol == SYM_BREAK) {
+    compile_break();
+  }
+  // break statement?
+  else if (symbol == SYM_CONTINUE) {
+    compile_continue();
   }
 }
 
@@ -5792,12 +5900,16 @@ void selfie_compile() {
         (char*) number_of_procedures,
         (char*) number_of_strings);
 
-      printf6("%s: %u calls, %u assignments, %u while, %u if, %u return\n", selfie_name,
+      printf3("%s: %u calls, %u assignments\n", selfie_name,
         (char*) number_of_calls,
-        (char*) number_of_assignments,
+        (char*) number_of_assignments);
+
+      printf6("%s: %u while, %u if, %u return, %u break, %u continue\n", selfie_name,
         (char*) number_of_while,
         (char*) number_of_if,
-        (char*) number_of_return);
+        (char*) number_of_return,
+        (char*) number_of_break,
+        (char*) number_of_continue);
 
       if (number_of_syntax_errors != 0) {
         printf3("%s: encountered %u syntax errors while compiling %s - omitting ELF output\n",

--- a/selfie.c
+++ b/selfie.c
@@ -4844,11 +4844,13 @@ void compile_while() {
 
   loop_dim = loop_dim + 1;
 
+  // temporarily store break-fixup-chain of parent loop
   outside_break_branches = break_branches;
 
-  outside_continue_branches = continue_branches;
-
   break_branches = 0;
+
+  // temporarily store continue-fixup-chain of parent loop
+  outside_continue_branches = continue_branches;
 
   continue_branches = 0;
 
@@ -4921,8 +4923,10 @@ void compile_while() {
 
   loop_dim = loop_dim - 1;
 
+  // restore break-fixup-chain of parent loop
   break_branches = outside_break_branches;
 
+  // restore continue-fixup-chain of parent loop
   continue_branches = outside_continue_branches;
 }
 
@@ -5062,7 +5066,7 @@ void compile_break() {
     syntax_error_symbol(SYM_BREAK);
 
   if (loop_dim > 0) {
-    // jump to procedure epilogue through fixup chain using absolute address
+    // jump to end of loop through fixup chain using absolute address
     emit_jal(REG_ZR, break_branches);
 
     // new head of fixup chain
@@ -5089,7 +5093,7 @@ void compile_continue() {
     syntax_error_symbol(SYM_CONTINUE);
 
   if (loop_dim > 0) {
-    // jump to procedure epilogue through fixup chain using absolute address
+    // jump to beginning of loop through fixup chain using absolute address
     emit_jal(REG_ZR, continue_branches);
 
     // new head of fixup chain

--- a/selfie.c
+++ b/selfie.c
@@ -688,7 +688,7 @@ uint64_t break_branches = 0; // fixup chain for break statements
 
 uint64_t continue_branches = 0; // fixup chain for continue statements
 
-uint64_t loop_dim = 0; // 0: currently not inside a loop | 1: inside a while loop | 2: inside a while loop which is inside a while loop etc.
+uint64_t loop_dim = 0; // amount of loops ("dimensions") we are in, 0 means not inside loop
 
 uint64_t return_type = 0; // return type of currently parsed procedure
 


### PR DESCRIPTION
Hi,
as written in a private message, I have implemented break and continue in my private repo and now offer to port that over to the main selfie repo.
It is implemented similar to how the return works using fixup chains. Additionally, the compiler knows if it is currently inside of a loop or not. Whenever a loop is compiled that is inside of another loop, the fixup chains are temporarily stored and then later restored at the end of the inner loop.

I can also adapt the for-loop assignment to check for successful implementation for break and continue if you would be interested in that. In my opinion, the assignment does not really get harder since including that in a for-loop implementation is very easy todo and barely different from how it is done by the while-loop implementation.

I have also updated the gammar. I incorporated the fact that break and continue can only be used inside of a while loop, which is why I did not add them to the actual statement definition, but I could of course also do that if its better that way.

If there is anything else needed or any issues, please let me know.

Tested compilation using both GCC and CLANG on a linux debian subsystem running on windows 10.