### PR TITLE
Fix execution depth when merging contexts.

### DIFF
--- a/tools/monster.c
+++ b/tools/monster.c
@@ -1352,7 +1352,7 @@ void merge(uint64_t* active_context, uint64_t* mergeable_context, uint64_t locat
   path_condition = smt_binary("or", get_path_condition(active_context), get_path_condition(mergeable_context));
   set_path_condition(active_context, path_condition);
 
-  if (get_execution_depth(mergeable_context) > get_execution_depth(active_context))
+  if (get_execution_depth(mergeable_context) < get_execution_depth(active_context))
     set_execution_depth(active_context, get_execution_depth(mergeable_context));
 
   if (get_beq_counter(mergeable_context) < get_beq_counter(active_context))


### PR DESCRIPTION
This changes `merge` to compute the minimum (instead of the maximum)
execution depth of two contexts being merged. If there is more than one
path to any merge point, then the context at that merge point should be
treated as if it were reached through the shortest path. Otherwise the
existence of just a single long path can make any otherwise easily
reachable merge point timeout prematurely.

Note that this makes handling of execution depth and branch counter
consistent, there is no inherent difference in how merge them.