### PR TITLE
Fix merging of shared symbolic memory in monster.

### DIFF
--- a/examples/symbolic/return-from-loop-1-35.c
+++ b/examples/symbolic/return-from-loop-1-35.c
@@ -1,0 +1,23 @@
+uint64_t main() {
+  uint64_t  a;
+  uint64_t* x;
+
+  x = malloc(8);
+
+  *x = 0; // touch memory
+
+  read(0, x, 1);
+
+  a = 0;
+
+  while (a < 10) {
+
+    // non-zero exit code if the input is a digit
+    if (*x - 48 == a)
+      return 1;
+
+    a = a + 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This fixes the update process of shared portions of the symbolic memory
when contexts are merged. It is only valid to un-share the topmost
fragment of a shared memory when a context is merged with the context
that it was originally cloned from. This is mostly ensured by the order
in which merging happens, but no longer holds true in the presence of
multiple return statements within a function body.

The newly added example demonstrates this issue and causes the bounded
loop to erroneously become unbounded due to the bogus un-sharing.

Also note that un-sharing of shared portions can be thought of as an
optimization. It won't affect correctness if we miss some un-sharing
opportunities. Overzealous un-sharing however will cause issues as the
example demonstrates.