### PR TITLE
Double the physical memory of hypster to 2MB for the os make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ emu: selfie.m
 
 # Run hypervisor between emulators
 os: selfie.m
-	./selfie -l selfie.m -m 2 -l selfie.m -y 1 -l selfie.m -m 1
+	./selfie -l selfie.m -m 2 -l selfie.m -y 2 -l selfie.m -m 1
 
 # Self-compile on two virtual machines
 vm: selfie.m selfie.s


### PR DESCRIPTION
Fixes Issue https://github.com/cksystemsteaching/selfie/issues/295 by increasing the physical memory of hypster from 1MB to 2MB for the `os` make target.