### PR TITLE
Fix missing register counter update in monster.

### DIFF
--- a/tools/monster.c
+++ b/tools/monster.c
@@ -761,6 +761,8 @@ void constrain_load() {
   if (is_virtual_address_valid(vaddr, WORDSIZE)) {
     if (is_valid_segment_read(vaddr)) {
       if (is_virtual_address_mapped(pt, vaddr)) {
+        update_register_counters();
+
         // semantics of load double word
         if (rd != REG_ZR) {
           sword = load_symbolic_memory(vaddr);
@@ -819,6 +821,8 @@ void constrain_store() {
   if (is_virtual_address_valid(vaddr, WORDSIZE)) {
     if (is_valid_segment_write(vaddr)) {
       if (is_virtual_address_mapped(pt, vaddr)) {
+        update_register_counters();
+
         // semantics of store double word
         store_symbolic_memory(vaddr,
           *(registers + rs2),


### PR DESCRIPTION
This is just to prevent the following bogus exception which aborts abstract interpretation completely if a register is first (and only) initialized with a load instruction.

`./selfie/monster: context sample.c throws uncaught exception: uninitialized register t1`