### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
+    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
 
     steps:
     - name: Checkout selfie

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -8,9 +8,32 @@ on:
   workflow_dispatch:
     inputs:
       assignmentid:
-        description: 'Assignment ID'     
+        description: 'Assignment ID'
+        type: choice
         required: true
-        default: 'self-compile'
+        options:
+        - bootstrapping
+        - self-compile
+        - print-your-name
+        - hex-literal
+        - bitwise-shift-compilation
+        - bitwise-shift-execution
+        - bitwise-and-or-not
+        - array
+        - array-multidimensional
+        - struct-declaration
+        - struct-execution
+        - for-loop
+        - logical-and-or-not
+        - lazy-evaluation
+        - assembler-parser
+        - self-assembler
+        - processes
+        - fork-wait
+        - fork-wait-exit
+        - lock
+        - threads
+        - treiber-stack
 
 jobs:
   auto-grade-selfie-assignment-on-linux:

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
-    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
 
     steps:
     - name: Checkout selfie
@@ -34,6 +33,7 @@ jobs:
     # extract assignment from "commit message [assignment]"
     - name: Parse commit message
       run: echo "ASSIGNMENT=$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')" >> $GITHUB_ENV
-      if: github.event_name == 'push'
+      if: ${{ (github.event_name == 'push') && ((matrix.os == 'ubuntu-latest') || (!github.event.repository.private)) }}
     - name: Autograde assignment
       run: if [ "$ASSIGNMENT" != 'skip ci' ]; then ./grader/self.py $ASSIGNMENT; fi
+      if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -34,6 +34,16 @@ on:
         - lock
         - threads
         - treiber-stack
+      oslinux:
+        description: 'Run on Linux'
+        type: boolean
+        required: true
+        default: true
+      osmacos:
+        description: 'Run on macOS'
+        type: boolean
+        required: true
+        default: true
 
 jobs:
   auto-grade-selfie-assignment-on-linux:
@@ -42,7 +52,7 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
-    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
+    if: ${{ ((github.event_name != 'workflow_dispatch') || (github.event.inputs.oslinux == 'true')) && ((!github.event.repository.private) || (github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')) }}
 
     steps:
     - name: Checkout selfie
@@ -64,7 +74,7 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
-    if: ${{ !github.event.repository.private }}
+    if: ${{ ((github.event_name != 'workflow_dispatch') || (github.event.inputs.osmacos == 'true')) && ((!github.event.repository.private) || (github.event_name == 'workflow_dispatch')) }}
 
     steps:
     - name: Checkout selfie

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
+    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
 
     steps:
     - name: Checkout selfie

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -5,6 +5,12 @@ on:
     paths:
     - '**.c'
     - '**.yml'
+  workflow_dispatch:
+    inputs:
+      assignmentid:
+        description: 'Assignment ID'     
+        required: true
+        default: 'skip ci'
 
 jobs:
   auto-grade-selfie-assignment:
@@ -15,6 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+      ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
 
     steps:
     - name: Checkout selfie
@@ -26,5 +33,6 @@ jobs:
     # extract assignment from "commit message [assignment]"
     - name: Parse commit message
       run: echo "ASSIGNMENT=$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')" >> $GITHUB_ENV
+      if: github.event_name == 'push'
     - name: Autograde assignment
       run: if [ "$ASSIGNMENT" != 'skip ci' ]; then ./grader/self.py $ASSIGNMENT; fi

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -13,12 +13,9 @@ on:
         default: 'self-compile'
 
 jobs:
-  auto-grade-selfie-assignment:
-    name: Run autograder
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  auto-grade-selfie-assignment-on-linux:
+    name: Run autograder on linux
+    runs-on: ubuntu-latest
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
@@ -33,7 +30,28 @@ jobs:
     # extract assignment from "commit message [assignment]"
     - name: Parse commit message
       run: echo "ASSIGNMENT=$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')" >> $GITHUB_ENV
-      if: ${{ (github.event_name == 'push') && ((matrix.os == 'ubuntu-latest') || (!github.event.repository.private)) }}
+      if: ${{ github.event_name == 'push' }}
     - name: Autograde assignment
       run: if [ "$ASSIGNMENT" != 'skip ci' ]; then ./grader/self.py $ASSIGNMENT; fi
-      if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
+
+  auto-grade-selfie-assignment-on-macos:
+    name: Run autograder on macOS
+    runs-on: macos-latest
+    env:
+      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+      ASSIGNMENT: ${{ github.event.inputs.assignmentid }}
+    if: ${{ !github.event.repository.private }}
+
+    steps:
+    - name: Checkout selfie
+      uses: actions/checkout@v2
+    - name: Use Python 3.7.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: "3.7.x"
+    # extract assignment from "commit message [assignment]"
+    - name: Parse commit message
+      run: echo "ASSIGNMENT=$(echo $COMMIT_MESSAGE | awk -F '[][]' '{print $2}')" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
+    - name: Autograde assignment
+      run: if [ "$ASSIGNMENT" != 'skip ci' ]; then ./grader/self.py $ASSIGNMENT; fi

--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -40,7 +40,7 @@ jobs:
   make-all-on-macos:
     name: Make all of selfie on macOS
     runs-on: macos-latest
-    if: !github.event.repository.private
+    if: ${{ !github.event.repository.private }}
 
     steps:
     - name: Checkout selfie
@@ -57,7 +57,7 @@ jobs:
   make-all-on-windows:
     name: Make all of selfie on Windows
     runs-on: windows-latest
-    if: !github.event.repository.private
+    if: ${{ !github.event.repository.private }}
 
     steps:
     - name: Checkout selfie

--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -24,6 +24,7 @@ jobs:
   make-all-on-linux:
     name: Make all of selfie on Linux
     runs-on: ubuntu-latest
+    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
 
     steps:
     - name: Checkout selfie
@@ -74,6 +75,7 @@ jobs:
   make-everything-on-docker:
     name: Make everything of selfie on docker
     runs-on: ubuntu-latest
+    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
 
     # usage:
     #

--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -18,6 +18,7 @@ on:
   schedule:
     # trigger fridays at 12am
     - cron: '0 0 * * 5'
+  workflow_dispatch
 
 jobs:
   make-all-on-linux:
@@ -39,6 +40,7 @@ jobs:
   make-all-on-macos:
     name: Make all of selfie on macOS
     runs-on: macos-latest
+    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
 
     steps:
     - name: Checkout selfie
@@ -55,6 +57,7 @@ jobs:
   make-all-on-windows:
     name: Make all of selfie on Windows
     runs-on: windows-latest
+    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
 
     steps:
     - name: Checkout selfie
@@ -71,6 +74,7 @@ jobs:
   make-everything-on-docker:
     name: Make everything of selfie on docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'cksystemsteaching/selfie' }}
 
     # usage:
     #
@@ -93,4 +97,3 @@ jobs:
         docker run cksystemsteaching/selfie make clean
         echo '${{ secrets.DOCKERHUB_PASSWORD }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
         docker push cksystemsteaching/selfie
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'cksystemsteaching/selfie' }}

--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -24,7 +24,7 @@ jobs:
   make-all-on-linux:
     name: Make all of selfie on Linux
     runs-on: ubuntu-latest
-    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
+    if: ${{ (!github.event.repository.private) || ((github.ref == 'refs/heads/main') && (github.event_name != 'schedule')) }}
 
     steps:
     - name: Checkout selfie
@@ -75,7 +75,7 @@ jobs:
   make-everything-on-docker:
     name: Make everything of selfie on docker
     runs-on: ubuntu-latest
-    if: ${{ (!github.event.repository.private) || (github.ref == 'refs/heads/main') }}
+    if: ${{ (!github.event.repository.private) || ((github.ref == 'refs/heads/main') && (github.event_name != 'schedule')) }}
 
     # usage:
     #

--- a/.github/workflows/selfie.yml
+++ b/.github/workflows/selfie.yml
@@ -18,7 +18,7 @@ on:
   schedule:
     # trigger fridays at 12am
     - cron: '0 0 * * 5'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   make-all-on-linux:
@@ -40,7 +40,7 @@ jobs:
   make-all-on-macos:
     name: Make all of selfie on macOS
     runs-on: macos-latest
-    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
+    if: !github.event.repository.private
 
     steps:
     - name: Checkout selfie
@@ -57,7 +57,7 @@ jobs:
   make-all-on-windows:
     name: Make all of selfie on Windows
     runs-on: windows-latest
-    if: ${{ (matrix.os == 'ubuntu-latest') || (!github.event.repository.private) }}
+    if: !github.event.repository.private
 
     steps:
     - name: Checkout selfie
@@ -74,7 +74,6 @@ jobs:
   make-everything-on-docker:
     name: Make everything of selfie on docker
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'cksystemsteaching/selfie' }}
 
     # usage:
     #
@@ -97,3 +96,4 @@ jobs:
         docker run cksystemsteaching/selfie make clean
         echo '${{ secrets.DOCKERHUB_PASSWORD }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
         docker push cksystemsteaching/selfie
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'cksystemsteaching/selfie' }}


### PR DESCRIPTION
Workflow improvements as discussed on monday.

**The Problem for students**
Specific parts of the current workflows eat up a lot of quota to a point where you can run all workflows maybe 3 times on total before you run out of avaiable minutes. This seems to be a problem of this semester's lecture (according to Michael) and has already been a problem of the same lecture when I took part in it last year.

**Solutions**
Make the running of jobs dependent on the OS the are run on (eg. 1 min on Linux = 10 min on MacOS), the repo they are in and if their repo is public or private, and the branch they are run on.

**Extras**
Add manual dispatchers to all workflows.

**Task List**
- [x] Disable jobs that run on Windows or MacOS since these are more "expensive" in minutes for private repos only
- [x] Disable jobs for all branches except the main branch for private repos only (still TODO. The idea is that only the final squash merge should run anything online, while any still-in-dev commites on dev branches should not eat up any quota)
- [x] Add manual dispatcher for the "Make everything selfie" workflow
- [x] Add manual dispatcher for the grader workflow and add an input field to determine the grader task (eg. hex-literal)
- [x] Disable scheduled run for private repos only