### PR TITLE
Fix treiber-stack grading task

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -325,10 +325,10 @@ def check_threads() -> List[Check]:
 def check_treiber_stack() -> List[Check]:
     return check_riscv_instruction(LR_INSTRUCTION, 'load-reserved.c') + \
         check_riscv_instruction(SC_INSTRUCTION, 'store-conditional.c') + \
-        check_execution('./selfie -c treiber-stack.c <assignment>stack-push.c -m 128',
+        check_execution('./selfie -c <assignment>stack-push.c -m 128',
                         'all pushed elements are actually in the treiber-stack',
                         success_criteria=lambda code, out: is_permutation_of(out, [0, 1, 2, 3, 4, 5, 6, 7])) + \
-        check_execution('./selfie -c treiber-stack.c <assignment>stack-pop.c -m 128',
+        check_execution('./selfie -c <assignment>stack-pop.c -m 128',
                         'all treiber-stack elements can be popped ',
                         success_criteria=lambda code, out: is_permutation_of(out, [0, 1, 2, 3, 4, 5, 6, 7]))
 


### PR DESCRIPTION
This should be the final issue/pr we discussed on monday.

Basically, the grader attempts to run the following:

`$ ./selfie -c treiber-stack.c "grader/assignments/treiber-stack/stack-push.c" -m 128`
`$ ./selfie -c treiber-stack.c "grader/assignments/treiber-stack/stack-pop.c" -m 128`

Which doesnt follow correct syntax. I believe it is just some kind of typo. "treiber-stack.c" does not exist in the repo. The single commit corrects these to:

`$ ./selfie -c "grader/assignments/treiber-stack/stack-push.c" -m 128`
`$ ./selfie -c "grader/assignments/treiber-stack/stack-pop.c" -m 128`