### PR TITLE
Add context struct size to lib - make monster and boehm-gc context extension dynamic

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -231,6 +231,10 @@ uint64_t UINT_MAX;       // maximum numerical value of target-dependent unsigned
 uint64_t WORDSIZE       = 8;  // target-dependent word size in bytes
 uint64_t WORDSIZEINBITS = 64; // WORDSIZE * 8
 
+// amount of entries of the context struct
+// contexts are extended in the symbolic execution engine and the Boehm garbage collector
+uint64_t CONTEXTENTRIES;
+
 uint64_t CHAR_EOF          =  -1; // end of file
 uint64_t CHAR_BACKSPACE    =   8; // ASCII code 8  = backspace
 uint64_t CHAR_TAB          =   9; // ASCII code 9  = tabulator
@@ -349,6 +353,9 @@ void init_library() {
   // compute 64-bit signed integer range using unsigned integer arithmetic
   INT64_MIN = two_to_the_power_of(SIZEOFUINT64INBITS - 1);
   INT64_MAX = INT64_MIN - 1;
+
+  // 9 uint64_t entries and 16 uint64_t* entries
+  CONTEXTENTRIES = 9 + 16;
 
   // target-dependent, see init_target()
   SIZEOFUINT     = SIZEOFUINT64;
@@ -2145,10 +2152,9 @@ uint64_t* delete_context(uint64_t* context, uint64_t* from);
 
 uint64_t* allocate_context(); // declaration avoids warning in the Boehm garbage collector
 
-// CAUTION: contexts are extended in the symbolic execution engine and the Boehm garbage collector!
-
 uint64_t* allocate_context() {
-  return smalloc(9 * SIZEOFUINT64STAR + 16 * SIZEOFUINT64);
+  // SIZEOFUINT64 == SIZEOFUINT64STAR (always, so no need to differentiate although it would be nicer)
+  return smalloc(CONTEXTENTRIES * SIZEOFUINT64);
 }
 
 uint64_t next_context(uint64_t* context)    { return (uint64_t) context; }

--- a/tools/boehm-gc.c
+++ b/tools/boehm-gc.c
@@ -30,28 +30,28 @@ void sweep_boehm(uint64_t* context);
 // --- boehm gc context extension ---
 
 // +----+-------------------------+
-// | 25 | chunk heap start        | start of the chunk heap segment
-// | 26 | chunk heap bump         | bump pointer of chunk heap segment
-// | 27 | chunk used list head    | pointer to head of the chunk used list
-// | 28 | chunk free list head    | pointer to head of the chunk free list
-// | 29 | small object free lists | pointer to array containing all small object free lists
+// | +0 | chunk heap start        | start of the chunk heap segment
+// | +1 | chunk heap bump         | bump pointer of chunk heap segment
+// | +2 | chunk used list head    | pointer to head of the chunk used list
+// | +3 | chunk free list head    | pointer to head of the chunk free list
+// | +4 | small object free lists | pointer to array containing all small object free lists
 // +----+-------------------------+
 
 uint64_t* allocate_context() {
-  return smalloc(14 * SIZEOFUINT64STAR + 16 * SIZEOFUINT64);
+  return smalloc(CONTEXTENTRIES * SIZEOFUINT64 + 5 * SIZEOFUINT64STAR);
 }
 
-uint64_t* get_chunk_heap_start(uint64_t* context)           { return (uint64_t*) *(context + 25); }
-uint64_t* get_chunk_heap_bump(uint64_t* context)            { return (uint64_t*) *(context + 26); }
-uint64_t* get_chunk_used_list_head(uint64_t* context)       { return (uint64_t*) *(context + 27); }
-uint64_t* get_chunk_free_list_head(uint64_t* context)       { return (uint64_t*) *(context + 28); }
-uint64_t* get_small_object_free_lists(uint64_t* context)    { return (uint64_t*) *(context + 29); }
+uint64_t* get_chunk_heap_start(uint64_t* context)           { return (uint64_t*) *(context + CONTEXTENTRIES); }
+uint64_t* get_chunk_heap_bump(uint64_t* context)            { return (uint64_t*) *(context + CONTEXTENTRIES + 1); }
+uint64_t* get_chunk_used_list_head(uint64_t* context)       { return (uint64_t*) *(context + CONTEXTENTRIES + 2); }
+uint64_t* get_chunk_free_list_head(uint64_t* context)       { return (uint64_t*) *(context + CONTEXTENTRIES + 3); }
+uint64_t* get_small_object_free_lists(uint64_t* context)    { return (uint64_t*) *(context + CONTEXTENTRIES + 4); }
 
-void set_chunk_heap_start(uint64_t* context, uint64_t* chunk_heap_start)                { *(context + 25) = (uint64_t) chunk_heap_start; }
-void set_chunk_heap_bump(uint64_t* context, uint64_t* chunk_heap_bump)                  { *(context + 26) = (uint64_t) chunk_heap_bump; }
-void set_chunk_used_list_head(uint64_t* context, uint64_t* chunk_used_list_head)        { *(context + 27) = (uint64_t) chunk_used_list_head; }
-void set_chunk_free_list_head(uint64_t* context, uint64_t* chunk_free_list_head)        { *(context + 28) = (uint64_t) chunk_free_list_head; }
-void set_small_object_free_lists(uint64_t* context, uint64_t* small_object_free_lists)  { *(context + 29) = (uint64_t) small_object_free_lists; }
+void set_chunk_heap_start(uint64_t* context, uint64_t* chunk_heap_start)                { *(context + CONTEXTENTRIES)     = (uint64_t) chunk_heap_start; }
+void set_chunk_heap_bump(uint64_t* context, uint64_t* chunk_heap_bump)                  { *(context + CONTEXTENTRIES + 1) = (uint64_t) chunk_heap_bump; }
+void set_chunk_used_list_head(uint64_t* context, uint64_t* chunk_used_list_head)        { *(context + CONTEXTENTRIES + 2) = (uint64_t) chunk_used_list_head; }
+void set_chunk_free_list_head(uint64_t* context, uint64_t* chunk_free_list_head)        { *(context + CONTEXTENTRIES + 3) = (uint64_t) chunk_free_list_head; }
+void set_small_object_free_lists(uint64_t* context, uint64_t* small_object_free_lists)  { *(context + CONTEXTENTRIES + 4) = (uint64_t) small_object_free_lists; }
 
 // getters and setters with different access in library/kernel
 

--- a/tools/monster.c
+++ b/tools/monster.c
@@ -150,34 +150,34 @@ uint64_t* copy_symbolic_context(uint64_t* original, uint64_t location, char* con
 
 // symbolic context extension:
 // +----+-----------------+
-// | 25 | execution depth | number of executed instructions
-// | 26 | path condition  | pointer to path condition
-// | 27 | symbolic memory | pointer to symbolic memory
-// | 28 | symbolic regs   | pointer to symbolic registers
-// | 29 | beq counter     | number of executed symbolic beq instructions
-// | 30 | merge partner   | pointer to the context from which this context was created
-// | 31 | call stack      | pointer to the corresponding node in the call stack tree
+// | +0 | execution depth | number of executed instructions
+// | +1 | path condition  | pointer to path condition
+// | +2 | symbolic memory | pointer to symbolic memory
+// | +3 | symbolic regs   | pointer to symbolic registers
+// | +4 | beq counter     | number of executed symbolic beq instructions
+// | +5 | merge partner   | pointer to the context from which this context was created
+// | +6 | call stack      | pointer to the corresponding node in the call stack tree
 // +----+-----------------+
 
 uint64_t* allocate_symbolic_context() {
-  return smalloc(9 * SIZEOFUINT64STAR + 16 * SIZEOFUINT64 + 5 * SIZEOFUINT64STAR + 2 * SIZEOFUINT64);
+  return smalloc(CONTEXTENTRIES * SIZEOFUINT64 + 5 * SIZEOFUINT64STAR + 2 * SIZEOFUINT64);
 }
 
-uint64_t  get_execution_depth(uint64_t* context) { return             *(context + 25); }
-char*     get_path_condition(uint64_t* context)  { return (char*)     *(context + 26); }
-uint64_t* get_symbolic_memory(uint64_t* context) { return (uint64_t*) *(context + 27); }
-uint64_t* get_symbolic_regs(uint64_t* context)   { return (uint64_t*) *(context + 28); }
-uint64_t  get_beq_counter(uint64_t* context)     { return             *(context + 29); }
-uint64_t* get_merge_partner(uint64_t* context)   { return (uint64_t*) *(context + 30); }
-uint64_t* get_call_stack(uint64_t* context)      { return (uint64_t*) *(context + 31); }
+uint64_t  get_execution_depth(uint64_t* context) { return             *(context + CONTEXTENTRIES); }
+char*     get_path_condition(uint64_t* context)  { return (char*)     *(context + CONTEXTENTRIES + 1); }
+uint64_t* get_symbolic_memory(uint64_t* context) { return (uint64_t*) *(context + CONTEXTENTRIES + 2); }
+uint64_t* get_symbolic_regs(uint64_t* context)   { return (uint64_t*) *(context + CONTEXTENTRIES + 3); }
+uint64_t  get_beq_counter(uint64_t* context)     { return             *(context + CONTEXTENTRIES + 4); }
+uint64_t* get_merge_partner(uint64_t* context)   { return (uint64_t*) *(context + CONTEXTENTRIES + 5); }
+uint64_t* get_call_stack(uint64_t* context)      { return (uint64_t*) *(context + CONTEXTENTRIES + 6); }
 
-void set_execution_depth(uint64_t* context, uint64_t depth)   { *(context + 25) =            depth; }
-void set_path_condition(uint64_t* context, char* condition)   { *(context + 26) = (uint64_t) condition; }
-void set_symbolic_memory(uint64_t* context, uint64_t* memory) { *(context + 27) = (uint64_t) memory; }
-void set_symbolic_regs(uint64_t* context, uint64_t* regs)     { *(context + 28) = (uint64_t) regs; }
-void set_beq_counter(uint64_t* context, uint64_t counter)     { *(context + 29) =            counter; }
-void set_merge_partner(uint64_t* context, uint64_t* partner)  { *(context + 30) = (uint64_t) partner; }
-void set_call_stack(uint64_t* context, uint64_t* stack)       { *(context + 31) = (uint64_t) stack; }
+void set_execution_depth(uint64_t* context, uint64_t depth)   { *(context + CONTEXTENTRIES)     =            depth; }
+void set_path_condition(uint64_t* context, char* condition)   { *(context + CONTEXTENTRIES + 1) = (uint64_t) condition; }
+void set_symbolic_memory(uint64_t* context, uint64_t* memory) { *(context + CONTEXTENTRIES + 2) = (uint64_t) memory; }
+void set_symbolic_regs(uint64_t* context, uint64_t* regs)     { *(context + CONTEXTENTRIES + 3) = (uint64_t) regs; }
+void set_beq_counter(uint64_t* context, uint64_t counter)     { *(context + CONTEXTENTRIES + 4) =            counter; }
+void set_merge_partner(uint64_t* context, uint64_t* partner)  { *(context + CONTEXTENTRIES + 5) = (uint64_t) partner; }
+void set_call_stack(uint64_t* context, uint64_t* stack)       { *(context + CONTEXTENTRIES + 6) = (uint64_t) stack; }
 
 // -----------------------------------------------------------------
 // -------------------------- MICROKERNEL --------------------------


### PR DESCRIPTION
As discussed in the meeting.
monster and boehm-gc should now dynamically adjust to any context struct size changes. I used 'CONTEXTENTRIES' as variable name because any 'SIZEOF' variable names would always be in bytes, and I did not want to break this convention.