### PR TITLE
Showcase the use of expect_symbol as mentioned in the lecture.

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -417,6 +417,7 @@ uint64_t identifier_string_match(uint64_t string_index);
 uint64_t identifier_or_keyword();
 
 void get_symbol();
+void expect_symbol(uint64_t expected_symbol);
 
 void handle_escape_sequence();
 
@@ -3931,6 +3932,13 @@ void get_symbol() {
   }
 }
 
+void expect_symbol(uint64_t expected_symbol) {
+  if (symbol == expected_symbol)
+    get_symbol();
+  else
+    syntax_error_symbol(expected_symbol);
+}
+
 void handle_escape_sequence() {
   // ignoring the backslash
   number_of_ignored_characters = number_of_ignored_characters + 1;
@@ -4728,19 +4736,13 @@ uint64_t compile_factor() {
 
       cast = compile_type();
 
-      if (symbol == SYM_RPARENTHESIS)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
+      expect_symbol(SYM_RPARENTHESIS);
 
     // not a cast: "(" expression ")"
     } else {
       type = compile_expression();
 
-      if (symbol == SYM_RPARENTHESIS)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
+      expect_symbol(SYM_RPARENTHESIS);
 
       // assert: allocated_temporaries == n + 1
 
@@ -4825,10 +4827,7 @@ uint64_t compile_factor() {
 
     type = compile_expression();
 
-    if (symbol == SYM_RPARENTHESIS)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_RPARENTHESIS);
+    expect_symbol(SYM_RPARENTHESIS);
   } else {
     syntax_error_unexpected();
 

--- a/selfie.c
+++ b/selfie.c
@@ -417,8 +417,8 @@ uint64_t identifier_string_match(uint64_t string_index);
 uint64_t identifier_or_keyword();
 
 void get_symbol();
-void expect_symbol(uint64_t expected_symbol);
-void require_symbol(uint64_t expected_symbol);
+void get_expected_symbol(uint64_t expected_symbol);
+void get_required_symbol(uint64_t expected_symbol);
 
 void handle_escape_sequence();
 
@@ -3933,14 +3933,14 @@ void get_symbol() {
   }
 }
 
-void expect_symbol(uint64_t expected_symbol) {
+void get_expected_symbol(uint64_t expected_symbol) {
   if (symbol == expected_symbol)
     get_symbol();
   else
     syntax_error_symbol(expected_symbol);
 }
 
-void require_symbol(uint64_t expected_symbol) {
+void get_required_symbol(uint64_t expected_symbol) {
   if (symbol == expected_symbol)
     get_symbol();
   else {
@@ -4747,13 +4747,13 @@ uint64_t compile_factor() {
 
       cast = compile_type();
 
-      expect_symbol(SYM_RPARENTHESIS);
+      get_expected_symbol(SYM_RPARENTHESIS);
 
     // not a cast: "(" expression ")"
     } else {
       type = compile_expression();
 
-      expect_symbol(SYM_RPARENTHESIS);
+      get_expected_symbol(SYM_RPARENTHESIS);
 
       // assert: allocated_temporaries == n + 1
 
@@ -4838,7 +4838,7 @@ uint64_t compile_factor() {
 
     type = compile_expression();
 
-    expect_symbol(SYM_RPARENTHESIS);
+    get_expected_symbol(SYM_RPARENTHESIS);
   } else {
     syntax_error_unexpected();
 
@@ -5103,7 +5103,7 @@ void compile_while() {
           while (is_not_rbrace_or_eof())
             compile_statement();
 
-          require_symbol(SYM_RBRACE);
+          get_required_symbol(SYM_RBRACE);
         } else
           // only one statement without {}
           compile_statement();
@@ -5161,7 +5161,7 @@ void compile_if() {
           while (is_not_rbrace_or_eof())
             compile_statement();
 
-          require_symbol(SYM_RBRACE);
+          get_required_symbol(SYM_RBRACE);
         } else
         // only one statement without {}
           compile_statement();
@@ -5186,7 +5186,7 @@ void compile_if() {
             while (is_not_rbrace_or_eof())
               compile_statement();
 
-            require_symbol(SYM_RBRACE);
+            get_required_symbol(SYM_RBRACE);
 
           // only one statement without {}
           } else
@@ -5214,7 +5214,7 @@ void compile_return() {
 
   // assert: allocated_temporaries == 0
 
-  expect_symbol(SYM_RETURN);
+  get_expected_symbol(SYM_RETURN);
 
   // optional: expression
   if (symbol != SYM_SEMICOLON) {
@@ -5280,7 +5280,7 @@ void compile_statement() {
       if (ltype != UINT64STAR_T)
         type_warning(UINT64STAR_T, ltype);
 
-      expect_symbol(SYM_RPARENTHESIS);
+      get_expected_symbol(SYM_RPARENTHESIS);
     } else {
       syntax_error_symbol(SYM_LPARENTHESIS);
 
@@ -5307,7 +5307,7 @@ void compile_statement() {
       tfree(1);
     }
 
-    expect_symbol(SYM_SEMICOLON);
+    get_expected_symbol(SYM_SEMICOLON);
   }
   // variable "=" expression | call
   else if (symbol == SYM_IDENTIFIER) {
@@ -5325,7 +5325,7 @@ void compile_statement() {
       // for missing return expressions
       emit_addi(REG_A0, REG_ZR, 0);
 
-      expect_symbol(SYM_SEMICOLON);
+      get_expected_symbol(SYM_SEMICOLON);
 
     // variable "=" expression
     } else if (symbol == SYM_ASSIGN) {
@@ -5356,7 +5356,7 @@ void compile_statement() {
 
       number_of_assignments = number_of_assignments + 1;
 
-      expect_symbol(SYM_SEMICOLON);
+      get_expected_symbol(SYM_SEMICOLON);
     } else
       syntax_error_unexpected();
   }
@@ -5372,7 +5372,7 @@ void compile_statement() {
   else if (symbol == SYM_RETURN) {
     compile_return();
 
-    expect_symbol(SYM_SEMICOLON);
+    get_expected_symbol(SYM_SEMICOLON);
   }
 
   // assert: allocated_temporaries == 0
@@ -5455,7 +5455,7 @@ uint64_t compile_initialization(uint64_t type) {
 
       cast = compile_type();
 
-      expect_symbol(SYM_RPARENTHESIS);
+      get_expected_symbol(SYM_RPARENTHESIS);
     }
 
     // optional: -
@@ -5475,7 +5475,7 @@ uint64_t compile_initialization(uint64_t type) {
     else
       syntax_error_unexpected();
 
-    expect_symbol(SYM_SEMICOLON);
+    get_expected_symbol(SYM_SEMICOLON);
   } else
     syntax_error_symbol(SYM_ASSIGN);
 
@@ -5533,7 +5533,7 @@ void compile_procedure(char* procedure, uint64_t type) {
         }
       }
 
-      expect_symbol(SYM_RPARENTHESIS);
+      get_expected_symbol(SYM_RPARENTHESIS);
     } else
       get_symbol();
   } else
@@ -5613,7 +5613,7 @@ void compile_procedure(char* procedure, uint64_t type) {
       // offset of local variables relative to frame pointer is negative
       compile_variable(-number_of_local_variable_bytes);
 
-      expect_symbol(SYM_SEMICOLON);
+      get_expected_symbol(SYM_SEMICOLON);
     }
 
     procedure_prologue(number_of_local_variable_bytes);
@@ -5842,7 +5842,7 @@ void macro_var_end() {
   if (symbol == SYM_IDENTIFIER) {
     get_symbol();
 
-    expect_symbol(SYM_RPARENTHESIS);
+    get_expected_symbol(SYM_RPARENTHESIS);
   } else
     syntax_error_symbol(SYM_IDENTIFIER);
 }

--- a/selfie.c
+++ b/selfie.c
@@ -417,8 +417,8 @@ uint64_t identifier_string_match(uint64_t string_index);
 uint64_t identifier_or_keyword();
 
 void get_symbol();
-void get_expected_symbol(uint64_t expected_symbol);
-void get_required_symbol(uint64_t expected_symbol);
+uint64_t get_expected_symbol(uint64_t expected_symbol);
+void get_required_symbol(uint64_t required_symbol);
 
 void handle_escape_sequence();
 
@@ -3933,21 +3933,23 @@ void get_symbol() {
   }
 }
 
-void get_expected_symbol(uint64_t expected_symbol) {
-  if (symbol == expected_symbol)
+uint64_t get_expected_symbol(uint64_t expected_symbol) {
+  uint64_t found;
+
+  if (symbol == expected_symbol) {
     get_symbol();
-  else
+    found = 1;
+  } else {
     syntax_error_symbol(expected_symbol);
+    found = 0;
+  }
+
+  return found;
 }
 
-void get_required_symbol(uint64_t expected_symbol) {
-  if (symbol == expected_symbol)
-    get_symbol();
-  else {
-    syntax_error_symbol(expected_symbol);
-    
+void get_required_symbol(uint64_t required_symbol) {
+  if (get_expected_symbol(required_symbol) == 0) 
     exit(EXITCODE_PARSERERROR);
-  }
 }
 
 void handle_escape_sequence() {

--- a/selfie.c
+++ b/selfie.c
@@ -5221,10 +5221,7 @@ void compile_return() {
 
   // assert: allocated_temporaries == 0
 
-  if (symbol == SYM_RETURN)
-    get_symbol();
-  else
-    syntax_error_symbol(SYM_RETURN);
+  expect_symbol(SYM_RETURN);
 
   // optional: expression
   if (symbol != SYM_SEMICOLON) {
@@ -5290,10 +5287,7 @@ void compile_statement() {
       if (ltype != UINT64STAR_T)
         type_warning(UINT64STAR_T, ltype);
 
-      if (symbol == SYM_RPARENTHESIS)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
+      expect_symbol(SYM_RPARENTHESIS);
     } else {
       syntax_error_symbol(SYM_LPARENTHESIS);
 
@@ -5320,10 +5314,7 @@ void compile_statement() {
       tfree(1);
     }
 
-    if (symbol == SYM_SEMICOLON)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_SEMICOLON);
+    expect_symbol(SYM_SEMICOLON);
   }
   // variable "=" expression | call
   else if (symbol == SYM_IDENTIFIER) {
@@ -5341,10 +5332,7 @@ void compile_statement() {
       // for missing return expressions
       emit_addi(REG_A0, REG_ZR, 0);
 
-      if (symbol == SYM_SEMICOLON)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_SEMICOLON);
+      expect_symbol(SYM_SEMICOLON);
 
     // variable "=" expression
     } else if (symbol == SYM_ASSIGN) {
@@ -5375,10 +5363,7 @@ void compile_statement() {
 
       number_of_assignments = number_of_assignments + 1;
 
-      if (symbol == SYM_SEMICOLON)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_SEMICOLON);
+      expect_symbol(SYM_SEMICOLON);
     } else
       syntax_error_unexpected();
   }
@@ -5394,10 +5379,7 @@ void compile_statement() {
   else if (symbol == SYM_RETURN) {
     compile_return();
 
-    if (symbol == SYM_SEMICOLON)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_SEMICOLON);
+    expect_symbol(SYM_SEMICOLON);
   }
 
   // assert: allocated_temporaries == 0
@@ -5480,10 +5462,7 @@ uint64_t compile_initialization(uint64_t type) {
 
       cast = compile_type();
 
-      if (symbol == SYM_RPARENTHESIS)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
+      expect_symbol(SYM_RPARENTHESIS);
     }
 
     // optional: -
@@ -5503,10 +5482,7 @@ uint64_t compile_initialization(uint64_t type) {
     else
       syntax_error_unexpected();
 
-    if (symbol == SYM_SEMICOLON)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_SEMICOLON);
+    expect_symbol(SYM_SEMICOLON);
   } else
     syntax_error_symbol(SYM_ASSIGN);
 
@@ -5564,10 +5540,7 @@ void compile_procedure(char* procedure, uint64_t type) {
         }
       }
 
-      if (symbol == SYM_RPARENTHESIS)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
+      expect_symbol(SYM_RPARENTHESIS);
     } else
       get_symbol();
   } else
@@ -5647,10 +5620,7 @@ void compile_procedure(char* procedure, uint64_t type) {
       // offset of local variables relative to frame pointer is negative
       compile_variable(-number_of_local_variable_bytes);
 
-      if (symbol == SYM_SEMICOLON)
-        get_symbol();
-      else
-        syntax_error_symbol(SYM_SEMICOLON);
+      expect_symbol(SYM_SEMICOLON);
     }
 
     procedure_prologue(number_of_local_variable_bytes);
@@ -5879,10 +5849,7 @@ void macro_var_end() {
   if (symbol == SYM_IDENTIFIER) {
     get_symbol();
 
-    if (symbol == SYM_RPARENTHESIS)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_RPARENTHESIS);
+    expect_symbol(SYM_RPARENTHESIS);
   } else
     syntax_error_symbol(SYM_IDENTIFIER);
 }

--- a/selfie.c
+++ b/selfie.c
@@ -3934,17 +3934,13 @@ void get_symbol() {
 }
 
 uint64_t get_expected_symbol(uint64_t expected_symbol) {
-  uint64_t found;
-
   if (symbol == expected_symbol) {
     get_symbol();
-    found = 1;
-  } else {
-    syntax_error_symbol(expected_symbol);
-    found = 0;
+    return 1;
   }
 
-  return found;
+  syntax_error_symbol(expected_symbol);
+  return 0;
 }
 
 void get_required_symbol(uint64_t required_symbol) {

--- a/selfie.c
+++ b/selfie.c
@@ -418,6 +418,7 @@ uint64_t identifier_or_keyword();
 
 void get_symbol();
 void expect_symbol(uint64_t expected_symbol);
+void require_symbol(uint64_t expected_symbol);
 
 void handle_escape_sequence();
 
@@ -3939,6 +3940,16 @@ void expect_symbol(uint64_t expected_symbol) {
     syntax_error_symbol(expected_symbol);
 }
 
+void require_symbol(uint64_t expected_symbol) {
+  if (symbol == expected_symbol)
+    get_symbol();
+  else {
+    syntax_error_symbol(expected_symbol);
+    
+    exit(EXITCODE_PARSERERROR);
+  }
+}
+
 void handle_escape_sequence() {
   // ignoring the backslash
   number_of_ignored_characters = number_of_ignored_characters + 1;
@@ -5092,13 +5103,7 @@ void compile_while() {
           while (is_not_rbrace_or_eof())
             compile_statement();
 
-          if (symbol == SYM_RBRACE)
-            get_symbol();
-          else {
-            syntax_error_symbol(SYM_RBRACE);
-
-            exit(EXITCODE_PARSERERROR);
-          }
+          require_symbol(SYM_RBRACE);
         } else
           // only one statement without {}
           compile_statement();
@@ -5156,13 +5161,7 @@ void compile_if() {
           while (is_not_rbrace_or_eof())
             compile_statement();
 
-          if (symbol == SYM_RBRACE)
-            get_symbol();
-          else {
-            syntax_error_symbol(SYM_RBRACE);
-
-            exit(EXITCODE_PARSERERROR);
-          }
+          require_symbol(SYM_RBRACE);
         } else
         // only one statement without {}
           compile_statement();
@@ -5187,13 +5186,7 @@ void compile_if() {
             while (is_not_rbrace_or_eof())
               compile_statement();
 
-            if (symbol == SYM_RBRACE)
-              get_symbol();
-            else {
-              syntax_error_symbol(SYM_RBRACE);
-
-              exit(EXITCODE_PARSERERROR);
-            }
+            require_symbol(SYM_RBRACE);
 
           // only one statement without {}
           } else


### PR DESCRIPTION
As I mentioned in the lecture today, the use of `expect_symbol`,
instead of the 4 lines that it replaces, can more clearly communicate 
what is happening in the code.

I am curious what you think about it @ckirsch.