### PR TITLE
compile_statement restructure (remake of #293)

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -50,7 +50,7 @@ variable          = type identifier .
 
 statement         = call ";" | while | if | return ";" | assignment ";" .
 
-assignment        = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression
+assignment        = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
 
 call              = identifier "(" [ expression { "," expression } ] ")" .
 

--- a/grammar.md
+++ b/grammar.md
@@ -35,43 +35,45 @@ letter = "a" | ... | "z" | "A" | ... | "Z" .
 C\* Grammar:
 
 ```
-cstar      = { variable [ "=" [ cast ] [ "-" ] value ] ";" |
-               ( "void" | type ) identifier procedure } .
+cstar          = { variable [ initialization ] ";" |
+                   ( "void" | type ) identifier procedure } .
 
-variable   = type identifier .
+initialization = "=" [ cast ] [ "-" ] value .
 
-type       = "uint64_t" [ "*" ] .
+variable       = type identifier .
 
-cast       = "(" type ")" .
+type           = "uint64_t" [ "*" ] .
 
-value      = integer_literal | character_literal .
+cast           = "(" type ")" .
 
-statement  = assignment ";" | if | while | call ";" | return ";" .
+value          = integer_literal | character_literal .
 
-assignment = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
+statement      = assignment ";" | if | while | call ";" | return ";" .
 
-expression = arithmetic [ ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) arithmetic ] .
+assignment     = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
 
-arithmetic = term { ( "+" | "-" ) term } .
+expression     = arithmetic [ ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) arithmetic ] .
 
-term       = factor { ( "*" | "/" | "%" ) factor } .
+arithmetic     = term { ( "+" | "-" ) term } .
 
-factor     = [ cast ] [ "-" ] [ "*" ] ( literal | identifier | call | "(" expression ")" ) .
+term           = factor { ( "*" | "/" | "%" ) factor } .
 
-literal    = value | string_literal .
+factor         = [ cast ] [ "-" ] [ "*" ] ( literal | identifier | call | "(" expression ")" ) .
 
-if         = "if" "(" expression ")"
-               ( statement | "{" { statement } "}" )
-             [ "else"
-               ( statement | "{" { statement } "}" ) ] .
+literal        = value | string_literal .
 
-while      = "while" "(" expression ")"
-               ( statement | "{" { statement } "}" ) .
+if             = "if" "(" expression ")"
+                   ( statement | "{" { statement } "}" )
+                 [ "else"
+                   ( statement | "{" { statement } "}" ) ] .
 
-procedure  = "(" [ variable { "," variable } [ "," "..." ] ] ")" ( ";" |
-             "{" { variable ";" } { statement } "}" ) .
+while          = "while" "(" expression ")"
+                   ( statement | "{" { statement } "}" ) .
 
-call       = identifier "(" [ expression { "," expression } ] ")" .
+procedure      = "(" [ variable { "," variable } [ "," "..." ] ] ")" ( ";" |
+                 "{" { variable ";" } { statement } "}" ) .
 
-return     = "return" [ expression ] .
+call           = identifier "(" [ expression { "," expression } ] ")" .
+
+return         = "return" [ expression ] .
 ```

--- a/grammar.md
+++ b/grammar.md
@@ -35,43 +35,43 @@ letter = "a" | ... | "z" | "A" | ... | "Z" .
 C\* Grammar:
 
 ```
-cstar             = { type identifier
-                      [ "=" [ cast ] [ "-" ] ( integer_literal | character_literal ) ] ";" |
-                    ( "void" | type ) identifier procedure } .
+cstar      = { variable [ "=" [ cast ] [ "-" ] value ] ";" |
+               ( "void" | type ) identifier procedure } .
 
-type              = "uint64_t" [ "*" ] .
+variable   = type identifier .
 
-cast              = "(" type ")" .
+type       = "uint64_t" [ "*" ] .
 
-procedure         = "(" [ variable { "," variable } [ "," "..." ] ] ")" ( ";" |
-                    "{" { variable ";" } { statement } "}" ) .
+cast       = "(" type ")" .
 
-variable          = type identifier .
+value      = integer_literal | character_literal .
 
-statement         = call ";" | while | if | return ";" | assignment ";" .
+statement  = assignment ";" | if | while | call ";" | return ";" .
 
-assignment        = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
+assignment = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
 
-call              = identifier "(" [ expression { "," expression } ] ")" .
+expression = arithmetic [ ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) arithmetic ] .
 
-expression        = simple_expression
-                    [ ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) simple_expression ] .
+arithmetic = term { ( "+" | "-" ) term } .
 
-simple_expression = term { ( "+" | "-" ) term } .
+term       = factor { ( "*" | "/" | "%" ) factor } .
 
-term              = factor { ( "*" | "/" | "%" ) factor } .
+factor     = [ cast ] [ "-" ] [ "*" ] ( literal | identifier | call | "(" expression ")" ) .
 
-factor            = [ cast ] [ "-" ] [ "*" ]
-                    ( integer_literal | character_literal | string_literal |
-                      identifier | call | "(" expression ")" ) .
+literal    = value | string_literal .
 
-while             = "while" "(" expression ")"
-                      ( statement | "{" { statement } "}" ) .
+if         = "if" "(" expression ")"
+               ( statement | "{" { statement } "}" )
+             [ "else"
+               ( statement | "{" { statement } "}" ) ] .
 
-if                = "if" "(" expression ")"
-                      ( statement | "{" { statement } "}" )
-                    [ "else"
-                      ( statement | "{" { statement } "}" ) ] .
+while      = "while" "(" expression ")"
+               ( statement | "{" { statement } "}" ) .
 
-return            = "return" [ expression ] .
+procedure  = "(" [ variable { "," variable } [ "," "..." ] ] ")" ( ";" |
+             "{" { variable ";" } { statement } "}" ) .
+
+call       = identifier "(" [ expression { "," expression } ] ")" .
+
+return     = "return" [ expression ] .
 ```

--- a/grammar.md
+++ b/grammar.md
@@ -48,8 +48,9 @@ procedure         = "(" [ variable { "," variable } [ "," "..." ] ] ")" ( ";" |
 
 variable          = type identifier .
 
-statement         = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression ";" |
-                    call ";" | while | if | return ";" .
+statement         = call ";" | while | if | return ";" | assignment ";" .
+
+assignment        = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression
 
 call              = identifier "(" [ expression { "," expression } ] ")" .
 

--- a/selfie.c
+++ b/selfie.c
@@ -4446,6 +4446,11 @@ uint64_t load_variable(char* variable) {
 
   offset = get_address(entry);
 
+  // the following if-construct is equivalent to just doing:
+  //   load_variable_address(variable);
+  //   emit_load(current_temporary(), 0, current_temporary());
+  // but it requires 1 less instruction this way
+
   if (is_signed_integer(offset, 12)) {
     talloc();
 

--- a/selfie.c
+++ b/selfie.c
@@ -698,7 +698,7 @@ uint64_t* get_variable(char* variable);
 uint64_t  load_variable_address(char* variable);
 uint64_t  load_variable(char* variable);
 void      load_small_and_medium_integer(uint64_t reg, uint64_t value);
-uint64_t  load_big_int(char* variable);
+uint64_t  load_big_integer(char* big_integer);
 void      load_integer(uint64_t value);
 void      load_string(char* string);
 
@@ -4504,13 +4504,13 @@ void load_small_and_medium_integer(uint64_t reg, uint64_t value) {
   }
 }
 
-uint64_t load_big_int(char* big_int) {
+uint64_t load_big_integer(char* big_integer) {
   uint64_t* entry;
   uint64_t offset;
 
   // assert: n = allocated_temporaries
 
-  entry = search_global_symbol_table(big_int, BIGINT);
+  entry = search_global_symbol_table(big_integer, BIGINT);
 
   offset = get_address(entry);
 
@@ -4551,7 +4551,7 @@ void load_integer(uint64_t value) {
       create_symbol_table_entry(GLOBAL_TABLE, integer, line_number, BIGINT, UINT64_T, value, -data_size);
     }
 
-    load_big_int(integer);
+    load_big_integer(integer);
   }
 
   // assert: allocated_temporaries == n + 1

--- a/selfie.c
+++ b/selfie.c
@@ -5283,119 +5283,119 @@ void compile_statement() {
   }
   // ["*"] variable "=" expression | call
   else {
-  // ["*"]
-  if (symbol == SYM_ASTERISK) {
-    get_symbol();
-
-    // "*" variable
-    if (symbol == SYM_IDENTIFIER) {
-      ltype = load_variable_or_big_int(identifier, VARIABLE);
-
-      if (ltype != UINT64STAR_T)
-        type_warning(UINT64STAR_T, ltype);
-
-      get_symbol();
-    // "*" "(" expression ")"
-    } else if (symbol == SYM_LPARENTHESIS) {
+    // ["*"]
+    if (symbol == SYM_ASTERISK) {
       get_symbol();
 
-      ltype = compile_expression();
+      // "*" variable
+      if (symbol == SYM_IDENTIFIER) {
+        ltype = load_variable_or_big_int(identifier, VARIABLE);
 
-      if (ltype != UINT64STAR_T)
-        type_warning(UINT64STAR_T, ltype);
+        if (ltype != UINT64STAR_T)
+          type_warning(UINT64STAR_T, ltype);
 
-      if (symbol == SYM_RPARENTHESIS)
         get_symbol();
-      else
-        syntax_error_symbol(SYM_RPARENTHESIS);
-    } else {
-      syntax_error_symbol(SYM_LPARENTHESIS);
-
-      return;
-    }
-
-    // "*" ( variable | "(" expression ")" ) "=" expression
-    if (symbol == SYM_ASSIGN) {
-      get_symbol();
-
-      rtype = compile_expression();
-
-      if (rtype != UINT64_T)
-        type_warning(UINT64_T, rtype);
-
-      emit_store(previous_temporary(), 0, current_temporary());
-
-      tfree(2);
-
-      number_of_assignments = number_of_assignments + 1;
-    } else {
-      syntax_error_symbol(SYM_ASSIGN);
-
-      tfree(1);
-    }
-
-    if (symbol == SYM_SEMICOLON)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_SEMICOLON);
-  }
-  // variable "=" expression | call
-  else if (symbol == SYM_IDENTIFIER) {
-    variable_or_procedure_name = identifier;
-
-    get_symbol();
-
-    // procedure call
-    if (symbol == SYM_LPARENTHESIS) {
-      get_symbol();
-
-      compile_call(variable_or_procedure_name);
-
-      // reset return register to initial return value
-      // for missing return expressions
-      emit_addi(REG_A0, REG_ZR, 0);
-
-      if (symbol == SYM_SEMICOLON)
+      // "*" "(" expression ")"
+      } else if (symbol == SYM_LPARENTHESIS) {
         get_symbol();
-      else
-        syntax_error_symbol(SYM_SEMICOLON);
 
-    // variable "=" expression
-    } else if (symbol == SYM_ASSIGN) {
-      entry = get_variable_or_big_int(variable_or_procedure_name, VARIABLE);
+        ltype = compile_expression();
 
-      ltype = get_type(entry);
+        if (ltype != UINT64STAR_T)
+          type_warning(UINT64STAR_T, ltype);
 
-      get_symbol();
-
-      rtype = compile_expression();
-
-      if (ltype != rtype)
-        type_warning(ltype, rtype);
-
-      offset = get_address(entry);
-
-      if (is_signed_integer(offset, 12)) {
-        emit_store(get_scope(entry), offset, current_temporary());
-
-        tfree(1);
+        if (symbol == SYM_RPARENTHESIS)
+          get_symbol();
+        else
+          syntax_error_symbol(SYM_RPARENTHESIS);
       } else {
-        load_upper_base_address(entry);
+        syntax_error_symbol(SYM_LPARENTHESIS);
 
-        emit_store(current_temporary(), sign_extend(get_bits(offset, 0, 12), 12), previous_temporary());
-
-        tfree(2);
+        return;
       }
 
-      number_of_assignments = number_of_assignments + 1;
+      // "*" ( variable | "(" expression ")" ) "=" expression
+      if (symbol == SYM_ASSIGN) {
+        get_symbol();
+
+        rtype = compile_expression();
+
+        if (rtype != UINT64_T)
+          type_warning(UINT64_T, rtype);
+
+        emit_store(previous_temporary(), 0, current_temporary());
+
+        tfree(2);
+
+        number_of_assignments = number_of_assignments + 1;
+      } else {
+        syntax_error_symbol(SYM_ASSIGN);
+
+        tfree(1);
+      }
 
       if (symbol == SYM_SEMICOLON)
         get_symbol();
       else
         syntax_error_symbol(SYM_SEMICOLON);
-    } else
-      syntax_error_unexpected();
-  }
+    }
+    // variable "=" expression | call
+    else if (symbol == SYM_IDENTIFIER) {
+      variable_or_procedure_name = identifier;
+
+      get_symbol();
+
+      // procedure call
+      if (symbol == SYM_LPARENTHESIS) {
+        get_symbol();
+
+        compile_call(variable_or_procedure_name);
+
+        // reset return register to initial return value
+        // for missing return expressions
+        emit_addi(REG_A0, REG_ZR, 0);
+
+        if (symbol == SYM_SEMICOLON)
+          get_symbol();
+        else
+          syntax_error_symbol(SYM_SEMICOLON);
+
+      // variable "=" expression
+      } else if (symbol == SYM_ASSIGN) {
+        entry = get_variable_or_big_int(variable_or_procedure_name, VARIABLE);
+
+        ltype = get_type(entry);
+
+        get_symbol();
+
+        rtype = compile_expression();
+
+        if (ltype != rtype)
+          type_warning(ltype, rtype);
+
+        offset = get_address(entry);
+
+        if (is_signed_integer(offset, 12)) {
+          emit_store(get_scope(entry), offset, current_temporary());
+
+          tfree(1);
+        } else {
+          load_upper_base_address(entry);
+
+          emit_store(current_temporary(), sign_extend(get_bits(offset, 0, 12), 12), previous_temporary());
+
+          tfree(2);
+        }
+
+        number_of_assignments = number_of_assignments + 1;
+
+        if (symbol == SYM_SEMICOLON)
+          get_symbol();
+        else
+          syntax_error_symbol(SYM_SEMICOLON);
+      } else
+        syntax_error_unexpected();
+    }
   }
 
   // assert: allocated_temporaries == 0

--- a/selfie.c
+++ b/selfie.c
@@ -5368,11 +5368,6 @@ void compile_statement() {
 
         get_symbol();
 
-        rtype = compile_expression();
-
-        if (ltype != rtype)
-          type_warning(ltype, rtype);
-
         offset = get_address(entry);
 
         if (is_signed_integer(offset, 12)) {
@@ -5385,7 +5380,12 @@ void compile_statement() {
           emit_addi(current_temporary(), current_temporary(), sign_extend(get_bits(offset, 0, 12), 12));
         }
 
-        emit_store(current_temporary(), 0, previous_temporary());
+        rtype = compile_expression();
+
+        if (ltype != rtype)
+          type_warning(ltype, rtype);
+
+        emit_store(previous_temporary(), 0, current_temporary());
 
         tfree(2);
 

--- a/selfie.c
+++ b/selfie.c
@@ -5302,6 +5302,8 @@ void compile_assignment() {
   uint64_t assignment;
   uint64_t dereference;
 
+  // assert: allocated_temporaries == 0
+
   assignment = 0;
 
   dereference = 0;
@@ -5331,12 +5333,12 @@ void compile_assignment() {
     }
     // ["*"] variable "=" expression
     else {
-      ltype = load_variable_address(variable_or_procedure_name);
-
-      // assert: allocated_temporaries == 1
-
       if (dereference)
-        emit_load(current_temporary(), current_temporary(), 0);
+        // load from address, value is in temporary
+        ltype = load_variable(variable_or_procedure_name);
+      else
+        // address is in temporary
+        ltype = load_variable_address(variable_or_procedure_name);
 
       // assert: allocated_temporaries == 1
 

--- a/selfie.c
+++ b/selfie.c
@@ -1096,7 +1096,7 @@ uint64_t ELF_HEADER_SIZE = 4096;
 uint64_t ELFCLASS64 = 2;
 uint64_t ELFCLASS32 = 1;
 
-uint64_t MAX_CODE_SIZE = 524288; // 256KB
+uint64_t MAX_CODE_SIZE = 524288; // 512KB
 uint64_t MAX_DATA_SIZE = 65536;  // 64KB
 
 uint64_t PK_CODE_START = 65536; // start of code segment at 0x10000 (according to RISC-V pk)

--- a/selfie.c
+++ b/selfie.c
@@ -5376,16 +5376,18 @@ void compile_statement() {
         offset = get_address(entry);
 
         if (is_signed_integer(offset, 12)) {
-          emit_store(get_scope(entry), offset, current_temporary());
+          talloc();
 
-          tfree(1);
+          emit_addi(current_temporary(), get_scope(entry), offset);
         } else {
           load_upper_base_address(entry);
 
-          emit_store(current_temporary(), sign_extend(get_bits(offset, 0, 12), 12), previous_temporary());
-
-          tfree(2);
+          emit_addi(current_temporary(), current_temporary(), sign_extend(get_bits(offset, 0, 12), 12));
         }
+
+        emit_store(current_temporary(), 0, previous_temporary());
+
+        tfree(2);
 
         number_of_assignments = number_of_assignments + 1;
 

--- a/selfie.c
+++ b/selfie.c
@@ -5264,6 +5264,25 @@ void compile_statement() {
       get_symbol();
   }
 
+  // while statement?
+  if (symbol == SYM_WHILE) {
+    compile_while();
+  }
+  // if statement?
+  else if (symbol == SYM_IF) {
+    compile_if();
+  }
+  // return statement?
+  else if (symbol == SYM_RETURN) {
+    compile_return();
+
+    if (symbol == SYM_SEMICOLON)
+      get_symbol();
+    else
+      syntax_error_symbol(SYM_SEMICOLON);
+  }
+  // ["*"] variable "=" expression | call
+  else {
   // ["*"]
   if (symbol == SYM_ASTERISK) {
     get_symbol();
@@ -5377,22 +5396,6 @@ void compile_statement() {
     } else
       syntax_error_unexpected();
   }
-  // while statement?
-  else if (symbol == SYM_WHILE) {
-    compile_while();
-  }
-  // if statement?
-  else if (symbol == SYM_IF) {
-    compile_if();
-  }
-  // return statement?
-  else if (symbol == SYM_RETURN) {
-    compile_return();
-
-    if (symbol == SYM_SEMICOLON)
-      get_symbol();
-    else
-      syntax_error_symbol(SYM_SEMICOLON);
   }
 
   // assert: allocated_temporaries == 0

--- a/selfie.c
+++ b/selfie.c
@@ -5362,16 +5362,11 @@ void compile_statement() {
 
       // variable "=" expression
       } else if (symbol == SYM_ASSIGN) {
+        get_symbol();
+
         entry = get_variable_or_big_int(variable_or_procedure_name, VARIABLE);
 
         ltype = get_type(entry);
-
-        get_symbol();
-
-        rtype = compile_expression();
-
-        if (ltype != rtype)
-          type_warning(ltype, rtype);
 
         offset = get_address(entry);
 
@@ -5385,7 +5380,12 @@ void compile_statement() {
           emit_addi(current_temporary(), current_temporary(), sign_extend(get_bits(offset, 0, 12), 12));
         }
 
-        emit_store(current_temporary(), 0, previous_temporary());
+        rtype = compile_expression();
+
+        if (ltype != rtype)
+          type_warning(ltype, rtype);
+
+        emit_store(previous_temporary(), 0, current_temporary());
 
         tfree(2);
 

--- a/selfie.c
+++ b/selfie.c
@@ -5362,11 +5362,16 @@ void compile_statement() {
 
       // variable "=" expression
       } else if (symbol == SYM_ASSIGN) {
-        get_symbol();
-
         entry = get_variable_or_big_int(variable_or_procedure_name, VARIABLE);
 
         ltype = get_type(entry);
+
+        get_symbol();
+
+        rtype = compile_expression();
+
+        if (ltype != rtype)
+          type_warning(ltype, rtype);
 
         offset = get_address(entry);
 
@@ -5380,12 +5385,7 @@ void compile_statement() {
           emit_addi(current_temporary(), current_temporary(), sign_extend(get_bits(offset, 0, 12), 12));
         }
 
-        rtype = compile_expression();
-
-        if (ltype != rtype)
-          type_warning(ltype, rtype);
-
-        emit_store(previous_temporary(), 0, current_temporary());
+        emit_store(current_temporary(), 0, previous_temporary());
 
         tfree(2);
 

--- a/selfie.c
+++ b/selfie.c
@@ -1080,7 +1080,7 @@ uint64_t ELF_HEADER_SIZE = 4096;
 uint64_t ELFCLASS64 = 2;
 uint64_t ELFCLASS32 = 1;
 
-uint64_t MAX_CODE_SIZE = 262144; // 256KB
+uint64_t MAX_CODE_SIZE = 524288; // 256KB
 uint64_t MAX_DATA_SIZE = 65536;  // 64KB
 
 uint64_t PK_CODE_START = 65536; // start of code segment at 0x10000 (according to RISC-V pk)


### PR DESCRIPTION
Remake of #293

The following needs to be done in my opinion for this to be merge-able:
- [ ] Compiler class should be done to prevent heavy merge conflicts for students
- [x] #314 needs to be fixed (`make 32-bit` fails right now on the code changes)
- [x] Obviously it needs to be approved


### Changes

This is a remake of the "big pr" that has been sitting idle for almost a year. However, there are no code disadvantages now.

Very important: This can not be merged during a semester. Otherwise there will be conflicts for anyone who has implemented/is working on any assignment which will induce some heavy headaches.

The changes are the following:

- Split current compile_statement into compile_statement (while, if, return, compile_assignment) and compile_assignment (call, assignments to variables)
- Restructure compile_assignment code so that assignments to `uint64_t` and `uint64_t*` (pointers) share the same control flow with pointers simply being dereferenced additionally
- This new structure is also more similar to compile_factor which is already using a more streamlined approach shared for pointers and non-pointers
- The new code is a lot shorter, easier to understand and has less if-else-cascades-depth

Additionally, address/value loading of variables was properly structured into methods and also there is no more sharing between `VARIABLE` and `BIGINT` (eg. `load_variable_or_big_int(...)`):
- `load_variable_or_big_int` split into `load_variable` and `load_big_int`
- `get_variable_or_big_int` was changed to `get_variable` (`get_big_int` not necessary as it would only be a single statement (call) which would also only be referenced a single time, so I just did said statement directly on the reference)
- New method: `load_variable_address` to load an address into a temporary, instead of the value at said address
- Any `if (is_signed_integer(offset, 12)) { ...` constructs are now only in said 3 methods (`load_variable`, `load_big_int`, `load_variable_address`)
- The result is clear responsibilities for methods and said methods being more versatile and usable, especially for the array and struct assignments

Impact for students (my personal opinion):
- I think doing the array assignments is a lot easier now; The relevant code is so much more clear now and these methods are useful and easy to understand
- However, right now the arrays are basically only `uint64_t[]` arrays. With this new addition, `uint64_t*[]` arrays would now also be very easy to do and barely require any additional code (just type checks, basically).