### PR TITLE
Small grader improvement for print-your-name

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -39,7 +39,7 @@ def check_self_compilation(mandatory=False) -> List[Check]:
 
 
 def check_print_your_name() -> List[Check]:
-    return check_execution('./selfie -c selfie.c -m 1',
+    return check_execution('./selfie -c selfie.c',
                            'selfie prints first and second name',
                            success_criteria=lambda code, out: contains_name(out))
 

--- a/grader/self.py
+++ b/grader/self.py
@@ -411,10 +411,10 @@ assignment_threads = Assignment('threads', 'Systems', 'threads',
            check_threads, parent = assignment_fork_wait_exit)
 assignment_threadsafe_malloc = Assignment('threadsafe-malloc', 'Systems', 'threadsafe-malloc',
            REPO_BLOB_BASE_URI + 'grader/systems-assignments.md#assignment-threadsafe-malloc',
-           check_threadsafe_malloc)
+           check_threadsafe_malloc, parent = assignment_threads)
 assignment_treiber_stack = Assignment('treiber-stack', 'Systems', 'treiber-stack',
            REPO_BLOB_BASE_URI + 'grader/systems-assignments.md#assignment-treiber-stack',
-           check_treiber_stack)
+           check_treiber_stack, parent = assignment_threadsafe_malloc)
 
 assignments: List[Assignment] = [
     assignment_print_your_name,


### PR DESCRIPTION
As discussed in the meeting. To explain what is happening:

The grader is running `./selfie -c selfie.c -m 1`. This is *what I believe* to be the desired output for the `print-your-name` assignment:, with the name shown in the first line, not above the synopsis:

```
./selfie: This is Luis Thiele's Selfie!                                                                                                                                                    
./selfie: this is the selfie system from selfie.cs.uni-salzburg.at with                                                                                                                    
...
./selfie: selfie executing 64-bit RISC-U binary selfie.c with 1MB physical memory on 64-bit mipster                                                                                        
./selfie: 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                                                                                 
synopsis: selfie.c { -c { source } | -o binary | ( -s | -S ) assembly | -l binary } [ ( -m | -d | -r | -y ) 0-4096 ... ]                                                                   
./selfie: 
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<                                                                                                 
./selfie: selfie.c exiting with exit code 0
...
```

For the output processing, the grader jumps to the last `>>>>>>>` line and starts parsing from there. This is why right now you would have to print out your name together with the synopsis to pass the grader. This might result in a lot of selfie systems not printing the names of the students in console, unless you run selfie without any arguments.

This PR simply changes the grader to run `./selfie -c selfie.c` instead, resulting in no `>>>>>>>` lines being printed and as such the grader actually checks the *real* first line of output.

There is another small fix I snuck in here, which just changes the LR/SC assignments to now show up as dependents on the threads assignment.