### PR TITLE
selfie: Add write_synced

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -166,6 +166,8 @@ uint64_t ratio_format_fractional_2(uint64_t a, uint64_t b);
 uint64_t percentage_format_integral_2(uint64_t a, uint64_t b);
 uint64_t percentage_format_fractional_2(uint64_t a, uint64_t b);
 
+uint64_t write_synced(uint64_t fd, uint64_t* buffer, uint64_t bytes_to_write); // a version of write which takes glibc buffering into account
+
 void put_character(char c);
 
 void print(char* s);
@@ -3046,6 +3048,35 @@ uint64_t percentage_format_fractional_2(uint64_t a, uint64_t b) {
     return 0;
 }
 
+uint64_t write_synced(uint64_t fd, uint64_t* buffer, uint64_t bytes_to_write) {
+  uint64_t bytes_written;
+  uint64_t total_bytes_written;
+
+  if (output_fd == 1) {
+    if (OS != SELFIE) {
+      // on bootlevel zero use printf to print on console
+      // to keep output synchronized with other printf output
+      total_bytes_written = 0;
+
+      while (total_bytes_written < bytes_to_write) {
+        bytes_written = printf("%c", load_character((char*) buffer, total_bytes_written));
+
+        if (bytes_written != 1)
+            // output failed
+            return total_bytes_written;
+
+        total_bytes_written = total_bytes_written + 1;
+      }
+    } else
+      // use regular write function
+      total_bytes_written = write(fd, buffer, bytes_to_write);
+  } else
+    // use regular write function
+    total_bytes_written = write(fd, buffer, bytes_to_write);
+
+  return total_bytes_written;
+}
+
 void put_character(char c) {
   uint64_t written_bytes;
 
@@ -3059,19 +3090,7 @@ void put_character(char c) {
 
     // assert: character_buffer is mapped
 
-    if (output_fd == 1) {
-      if (OS != SELFIE)
-        // on bootlevel zero use printf to print on console
-        // to keep output synchronized with other printf output
-        written_bytes = printf("%c", c);
-      else
-        // on non-zero bootlevel use write to print on console
-        // to avoid infinite loop back to printf
-        written_bytes = write(output_fd, (uint64_t*) character_buffer, 1);
-    } else
-      // try to write 1 character from character_buffer
-      // into file with output_fd file descriptor
-      written_bytes = write(output_fd, (uint64_t*) character_buffer, 1);
+    written_bytes = write_synced(output_fd, (uint64_t*) character_buffer, 1);
 
     if (written_bytes != 1) {
       // output failed
@@ -7601,7 +7620,7 @@ void implement_write(uint64_t* context) {
         if (is_virtual_address_mapped(get_pt(context), vbuffer)) {
           buffer = tlb(get_pt(context), vbuffer);
 
-          actually_written = sign_extend(write(fd, buffer, bytes_to_write), SYSCALL_BITWIDTH);
+          actually_written = sign_extend(write_synced(fd, buffer, bytes_to_write), SYSCALL_BITWIDTH);
 
           if (actually_written == bytes_to_write) {
             written_total = written_total + actually_written;


### PR DESCRIPTION
Currently, selfie directly uses the host's `write` function when implementing `SYS_WRITE` for higher bootlevels. This however causes issues with glibc buffering when these instances attempt to write to FD 1, causing output to appear out of order to the grader. As such, a new function `write_synced` is added which properly handles the case of writing to console for the highest bootlevel, by using `printf` (which is properly synced) to do so.

This fixes the issue addressed in both #337 and #338.