### PR TITLE
GCC RISC-V support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # This is the Makefile of the selfie system.
 
 # Compiler flags
-CFLAGS := -Wall -Wextra -O3 -D'uint64_t=unsigned long'
+CFLAGS := -Wall -Wextra -O3 -D'uint64_t=unsigned long' -Wno-sign-compare -include "unistd.h" -include "fcntl.h"
 
 # Bootstrap selfie.c into selfie executable
 selfie: selfie.c

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # This is the Makefile of the selfie system.
 
 # Compiler flags
-CFLAGS := -Wall -Wextra -O3 -Wno-sign-compare -include "stdint.h" -include "unistd.h" -include "fcntl.h"
+CFLAGS := -Wall -Wextra -O3 -Wno-sign-compare -Wno-unused-result -include "stdint.h" -include "unistd.h" -include "fcntl.h"
 
 # Bootstrap selfie.c into selfie executable
 selfie: selfie.c

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # This is the Makefile of the selfie system.
 
 # Compiler flags
-CFLAGS := -Wall -Wextra -O3 -Wno-sign-compare -include "unistd.h" -include "fcntl.h"
+CFLAGS := -Wall -Wextra -O3 -Wno-sign-compare -include "stdint.h" -include "unistd.h" -include "fcntl.h"
 
 # Bootstrap selfie.c into selfie executable
 selfie: selfie.c

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # This is the Makefile of the selfie system.
 
 # Compiler flags
-CFLAGS := -Wall -Wextra -O3 -D'uint64_t=unsigned long' -Wno-sign-compare -include "unistd.h" -include "fcntl.h"
+CFLAGS := -Wall -Wextra -O3 -Wno-sign-compare -include "unistd.h" -include "fcntl.h"
 
 # Bootstrap selfie.c into selfie executable
 selfie: selfie.c

--- a/examples/bounds.c
+++ b/examples/bounds.c
@@ -16,27 +16,27 @@ uint64_t main() {
 
   // print UINT64_MAX in decimal
   print("UINT64_MAX in decimal:     ");
-  print_unsigned_integer(UINT64_MAX);
+  print_unsigned_integer(S_UINT64_MAX);
   println();
 
   // print UINT64_MAX in decimal
   print("UINT64_MAX in decimal:     ");
-  print_integer(UINT64_MAX);
+  print_integer(S_UINT64_MAX);
   print(" (as signed 64-bit integer)\n");
 
   // print UINT64_MAX in hexadecimal
   print("UINT64_MAX in hexadecimal: ");
-  print_hexadecimal(UINT64_MAX, 0);
+  print_hexadecimal(S_UINT64_MAX, 0);
   println();
 
   // print UINT64_MAX in octal
   print("UINT64_MAX in octal:       ");
-  print_octal(UINT64_MAX, 0);
+  print_octal(S_UINT64_MAX, 0);
   println();
 
   // print UINT64_MAX in binary
   print("UINT64_MAX in binary:      ");
-  print_binary(UINT64_MAX, 64);
+  print_binary(S_UINT64_MAX, 64);
   println();
 
   // print 0 in decimal
@@ -61,46 +61,46 @@ uint64_t main() {
 
   // print INT64_MAX in decimal
   print("INT64_MAX in decimal:      ");
-  print_integer(INT64_MAX);
+  print_integer(S_INT64_MAX);
   println();
 
   // print INT64_MAX in hexadecimal
   print("INT64_MAX in hexadecimal:  ");
-  print_hexadecimal(INT64_MAX, 0);
+  print_hexadecimal(S_INT64_MAX, 0);
   println();
 
   // print INT64_MAX in octal
   print("INT64_MAX in octal:        ");
-  print_octal(INT64_MAX, 0);
+  print_octal(S_INT64_MAX, 0);
   println();
 
   // print INT64_MAX in binary
   print("INT64_MAX in binary:       ");
-  print_binary(INT64_MAX, 64);
+  print_binary(S_INT64_MAX, 64);
   println();
 
   // print INT64_MIN in decimal
   print("INT64_MIN in decimal:      ");
-  print_integer(INT64_MIN);
+  print_integer(S_INT64_MIN);
   println();
 
   // print INT64_MIN in decimal
   print("INT64_MIN in decimal:      ");
-  print_unsigned_integer(INT64_MIN);
+  print_unsigned_integer(S_INT64_MIN);
   print(" (as unsigned integer)\n");
 
   // print INT64_MIN in hexadecimal
   print("INT64_MIN in hexadecimal:  ");
-  print_hexadecimal(INT64_MIN, 0);
+  print_hexadecimal(S_INT64_MIN, 0);
   println();
 
   // print INT64_MIN in octal
   print("INT64_MIN in octal:        ");
-  print_octal(INT64_MIN, 0);
+  print_octal(S_INT64_MIN, 0);
   println();
 
   // print INT64_MIN in binary
   print("INT64_MIN in binary:       ");
-  print_binary(INT64_MIN, 64);
+  print_binary(S_INT64_MIN, 64);
   println();
 }

--- a/examples/overflows.c
+++ b/examples/overflows.c
@@ -16,22 +16,22 @@ uint64_t main() {
 
   // print UINT64_MAX+1 in decimal
   print("UINT64_MAX+1 in decimal:     ");
-  print_unsigned_integer(UINT64_MAX+1);
+  print_unsigned_integer(S_UINT64_MAX+1);
   println();
 
   // print UINT64_MAX+1 in hexadecimal
   print("UINT64_MAX+1 in hexadecimal: ");
-  print_hexadecimal(UINT64_MAX+1, 0);
+  print_hexadecimal(S_UINT64_MAX+1, 0);
   println();
 
   // print UINT64_MAX+1 in octal
   print("UINT64_MAX+1 in octal:       ");
-  print_octal(UINT64_MAX+1, 0);
+  print_octal(S_UINT64_MAX+1, 0);
   println();
 
   // print UINT64_MAX+1 in binary
   print("UINT64_MAX+1 in binary:      ");
-  print_binary(UINT64_MAX+1, 64);
+  print_binary(S_UINT64_MAX+1, 64);
   println();
 
   // print 0-1 in decimal
@@ -61,51 +61,51 @@ uint64_t main() {
 
   // print INT64_MAX+1 in decimal
   print("INT64_MAX+1 in decimal:      ");
-  print_integer(INT64_MAX+1);
+  print_integer(S_INT64_MAX+1);
   print(" (as signed 64-bit integer)\n");
 
   // print INT64_MAX+1 in decimal
   print("INT64_MAX+1 in decimal:      ");
-  print_unsigned_integer(INT64_MAX+1);
+  print_unsigned_integer(S_INT64_MAX+1);
   print(" (as unsigned integer)\n");
 
   // print INT64_MAX+1 in hexadecimal
   print("INT64_MAX+1 in hexadecimal:  ");
-  print_hexadecimal(INT64_MAX+1, 0);
+  print_hexadecimal(S_INT64_MAX+1, 0);
   println();
 
   // print INT64_MAX+1 in octal
   print("INT64_MAX+1 in octal:        ");
-  print_octal(INT64_MAX+1, 0);
+  print_octal(S_INT64_MAX+1, 0);
   println();
 
   // print INT64_MAX+1 in binary
   print("INT64_MAX+1 in binary:       ");
-  print_binary(INT64_MAX+1, 64);
+  print_binary(S_INT64_MAX+1, 64);
   println();
 
   // print INT64_MIN-1 in decimal
   print("INT64_MIN-1 in decimal:      ");
-  print_integer(INT64_MIN-1);
+  print_integer(S_INT64_MIN-1);
   print(" (as signed 64-bit integer)\n");
 
   // print INT64_MIN-1 in decimal
   print("INT64_MIN-1 in decimal:      ");
-  print_unsigned_integer(INT64_MIN-1);
+  print_unsigned_integer(S_INT64_MIN-1);
   print(" (as unsigned integer)\n");
 
   // print INT64_MIN-1 in hexadecimal
   print("INT64_MIN-1 in hexadecimal:  ");
-  print_hexadecimal(INT64_MIN-1, 0);
+  print_hexadecimal(S_INT64_MIN-1, 0);
   println();
 
   // print INT64_MIN-1 in octal
   print("INT64_MIN-1 in octal:        ");
-  print_octal(INT64_MIN-1, 0);
+  print_octal(S_INT64_MIN-1, 0);
   println();
 
   // print INT64_MIN-1 in binary
   print("INT64_MIN-1 in binary:       ");
-  print_binary(INT64_MIN-1, 64);
+  print_binary(S_INT64_MIN-1, 64);
   println();
 }

--- a/selfie.c
+++ b/selfie.c
@@ -221,11 +221,6 @@ uint64_t SIZEOFUINT64STARINBITS = 64; // SIZEOFUINT64STAR * 8
 
 uint64_t* power_of_two_table;
 
-uint64_t UINT64_MAX; // maximum numerical value of an unsigned 64-bit integer
-
-uint64_t INT64_MAX; // maximum numerical value of a signed 64-bit integer
-uint64_t INT64_MIN; // minimum numerical value of a signed 64-bit integer
-
 uint64_t SINGLEWORDSIZE       = 4;  // single-word size in bytes
 uint64_t SINGLEWORDSIZEINBITS = 32; // single-word size in bits
 
@@ -319,13 +314,6 @@ void init_library() {
 
     i = i + 1;
   }
-
-  // compute 64-bit unsigned integer range using signed integer arithmetic
-  UINT64_MAX = -1;
-
-  // compute 64-bit signed integer range using unsigned integer arithmetic
-  INT64_MIN = two_to_the_power_of(SIZEOFUINT64INBITS - 1);
-  INT64_MAX = INT64_MIN - 1;
 
   // target-dependent, see init_target()
   SIZEOFUINT     = SIZEOFUINT64;

--- a/selfie.c
+++ b/selfie.c
@@ -221,7 +221,7 @@ uint64_t SIZEOFUINT64STARINBITS = 64; // SIZEOFUINT64STAR * 8
 
 uint64_t* power_of_two_table;
 
-uint64_t S_US_INT64_MAX; // maximum numerical value of an unsigned 64-bit integer
+uint64_t S_UINT64_MAX; // maximum numerical value of an unsigned 64-bit integer
 
 uint64_t S_INT64_MAX; // maximum numerical value of a signed 64-bit integer
 uint64_t S_INT64_MIN; // minimum numerical value of a signed 64-bit integer
@@ -321,7 +321,7 @@ void init_library() {
   }
 
   // compute 64-bit unsigned integer range using signed integer arithmetic
-  S_US_INT64_MAX = -1;
+  S_UINT64_MAX = -1;
 
   // compute 64-bit signed integer range using unsigned integer arithmetic
   S_INT64_MIN = two_to_the_power_of(SIZEOFUINT64INBITS - 1);
@@ -329,7 +329,7 @@ void init_library() {
 
   // target-dependent, see init_target()
   SIZEOFUINT     = SIZEOFUINT64;
-  UINT_MAX       = S_US_INT64_MAX;
+  UINT_MAX       = S_UINT64_MAX;
   WORDSIZE       = SIZEOFUINT64;
   WORDSIZEINBITS = WORDSIZE * 8;
 
@@ -2530,7 +2530,7 @@ void init_target() {
   if (IS64BITTARGET) {
     if (IS64BITSYSTEM) {
       SIZEOFUINT = SIZEOFUINT64;
-      UINT_MAX   = S_US_INT64_MAX;
+      UINT_MAX   = S_UINT64_MAX;
 
       WORDSIZE       = SIZEOFUINT64;
       WORDSIZEINBITS = WORDSIZE * 8;
@@ -2556,7 +2556,7 @@ void init_target() {
       WORDSIZE = SINGLEWORDSIZE;
     } else {
       SIZEOFUINT = SIZEOFUINT64;
-      UINT_MAX   = S_US_INT64_MAX;
+      UINT_MAX   = S_UINT64_MAX;
 
       WORDSIZE = SIZEOFUINT64;
     }
@@ -2668,7 +2668,7 @@ uint64_t signed_less_than(uint64_t a, uint64_t b) {
   // S_INT64_MIN <= n <= S_INT64_MAX iff
   // S_INT64_MIN + S_INT64_MIN <= n + S_INT64_MIN <= S_INT64_MAX + S_INT64_MIN iff
   // -2^64 <= n + S_INT64_MIN <= 2^64 - 1 (sign-extended to 65 bits) iff
-  // 0 <= n + S_INT64_MIN <= S_US_INT64_MAX
+  // 0 <= n + S_INT64_MIN <= S_UINT64_MAX
   return a + S_INT64_MIN < b + S_INT64_MIN;
 }
 
@@ -6352,7 +6352,7 @@ uint64_t is_temporary_register(uint64_t reg) {
 void read_register_wrap(uint64_t reg, uint64_t wrap) {
   if (*(writes_per_register + reg) > 0) {
     // register has been written to before
-    if (*(reads_per_register + reg) < S_US_INT64_MAX)
+    if (*(reads_per_register + reg) < S_UINT64_MAX)
       *(reads_per_register + reg) = *(reads_per_register + reg) + 1;
 
     // tolerate unwrapped values in register-to-register transfers
@@ -6387,7 +6387,7 @@ void write_register_wrap(uint64_t reg, uint64_t wrap) {
     if (*(registers + REG_SP) < stack_peak)
       stack_peak = *(registers + REG_SP);
 
-  if (*(writes_per_register + reg) < S_US_INT64_MAX)
+  if (*(writes_per_register + reg) < S_UINT64_MAX)
     *(writes_per_register + reg) = *(writes_per_register + reg) + 1;
 }
 
@@ -10486,7 +10486,7 @@ uint64_t instruction_with_max_counter(uint64_t* counters, uint64_t max) {
   uint64_t i;
   uint64_t c;
 
-  a = S_US_INT64_MAX;
+  a = S_UINT64_MAX;
 
   n = 0;
   i = 0;
@@ -10505,10 +10505,10 @@ uint64_t instruction_with_max_counter(uint64_t* counters, uint64_t max) {
     i = i + 1;
   }
 
-  if (a != S_US_INT64_MAX)
+  if (a != S_UINT64_MAX)
     return a * INSTRUCTIONSIZE;
   else
-    return S_US_INT64_MAX;
+    return S_UINT64_MAX;
 }
 
 uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint64_t max) {
@@ -10517,7 +10517,7 @@ uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint6
 
   a = instruction_with_max_counter(counters, max);
 
-  if (a != S_US_INT64_MAX) {
+  if (a != S_UINT64_MAX) {
     c = *(counters + a / INSTRUCTIONSIZE);
 
     // CAUTION: we reset counter to avoid reporting it again
@@ -10539,7 +10539,7 @@ uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint6
 
 void print_per_instruction_profile(char* message, uint64_t total, uint64_t* counters) {
   printf("%s: %s%lu", selfie_name, message, total);
-  print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, S_US_INT64_MAX)));
+  print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, S_UINT64_MAX)));
   println();
 }
 
@@ -11476,9 +11476,9 @@ uint64_t mixter(uint64_t* to_context, uint64_t mix) {
 
   mslice = TIMESLICE;
 
-  if (mslice <= S_US_INT64_MAX / 100)
+  if (mslice <= S_UINT64_MAX / 100)
     mslice = mslice * mix / 100;
-  else if (mslice <= S_US_INT64_MAX / 10)
+  else if (mslice <= S_UINT64_MAX / 10)
     mslice = mslice / 10 * (mix / 10);
   else
     mslice = mslice / 100 * mix;

--- a/selfie.c
+++ b/selfie.c
@@ -221,6 +221,11 @@ uint64_t SIZEOFUINT64STARINBITS = 64; // SIZEOFUINT64STAR * 8
 
 uint64_t* power_of_two_table;
 
+uint64_t S_US_INT64_MAX; // maximum numerical value of an unsigned 64-bit integer
+
+uint64_t S_INT64_MAX; // maximum numerical value of a signed 64-bit integer
+uint64_t S_INT64_MIN; // minimum numerical value of a signed 64-bit integer
+
 uint64_t SINGLEWORDSIZE       = 4;  // single-word size in bytes
 uint64_t SINGLEWORDSIZEINBITS = 32; // single-word size in bits
 
@@ -315,9 +320,16 @@ void init_library() {
     i = i + 1;
   }
 
+  // compute 64-bit unsigned integer range using signed integer arithmetic
+  S_US_INT64_MAX = -1;
+
+  // compute 64-bit signed integer range using unsigned integer arithmetic
+  S_INT64_MIN = two_to_the_power_of(SIZEOFUINT64INBITS - 1);
+  S_INT64_MAX = S_INT64_MIN - 1;
+
   // target-dependent, see init_target()
   SIZEOFUINT     = SIZEOFUINT64;
-  UINT_MAX       = UINT64_MAX;
+  UINT_MAX       = S_US_INT64_MAX;
   WORDSIZE       = SIZEOFUINT64;
   WORDSIZEINBITS = WORDSIZE * 8;
 
@@ -472,7 +484,7 @@ char* string     = (char*) 0; // stores scanned string
 
 uint64_t literal = 0; // numerical value of most recently scanned integer or character
 
-uint64_t integer_is_signed = 0; // enforce INT64_MIN limit if '-' was scanned before
+uint64_t integer_is_signed = 0; // enforce S_INT64_MIN limit if '-' was scanned before
 
 uint64_t symbol; // most recently recognized symbol
 
@@ -2518,7 +2530,7 @@ void init_target() {
   if (IS64BITTARGET) {
     if (IS64BITSYSTEM) {
       SIZEOFUINT = SIZEOFUINT64;
-      UINT_MAX   = UINT64_MAX;
+      UINT_MAX   = S_US_INT64_MAX;
 
       WORDSIZE       = SIZEOFUINT64;
       WORDSIZEINBITS = WORDSIZE * 8;
@@ -2544,7 +2556,7 @@ void init_target() {
       WORDSIZE = SINGLEWORDSIZE;
     } else {
       SIZEOFUINT = SIZEOFUINT64;
-      UINT_MAX   = UINT64_MAX;
+      UINT_MAX   = S_US_INT64_MAX;
 
       WORDSIZE = SIZEOFUINT64;
     }
@@ -2653,24 +2665,24 @@ uint64_t max(uint64_t a, uint64_t b) {
 }
 
 uint64_t signed_less_than(uint64_t a, uint64_t b) {
-  // INT64_MIN <= n <= INT64_MAX iff
-  // INT64_MIN + INT64_MIN <= n + INT64_MIN <= INT64_MAX + INT64_MIN iff
-  // -2^64 <= n + INT64_MIN <= 2^64 - 1 (sign-extended to 65 bits) iff
-  // 0 <= n + INT64_MIN <= UINT64_MAX
-  return a + INT64_MIN < b + INT64_MIN;
+  // S_INT64_MIN <= n <= S_INT64_MAX iff
+  // S_INT64_MIN + S_INT64_MIN <= n + S_INT64_MIN <= S_INT64_MAX + S_INT64_MIN iff
+  // -2^64 <= n + S_INT64_MIN <= 2^64 - 1 (sign-extended to 65 bits) iff
+  // 0 <= n + S_INT64_MIN <= S_US_INT64_MAX
+  return a + S_INT64_MIN < b + S_INT64_MIN;
 }
 
 uint64_t signed_division(uint64_t a, uint64_t b) {
   // assert: b != 0
-  // assert: a == INT64_MIN -> b != -1
-  if (a == INT64_MIN)
-    if (b == INT64_MIN)
+  // assert: a == S_INT64_MIN -> b != -1
+  if (a == S_INT64_MIN)
+    if (b == S_INT64_MIN)
       return 1;
     else if (signed_less_than(b, 0))
-      return INT64_MIN / absolute(b);
+      return S_INT64_MIN / absolute(b);
     else
-      return -(INT64_MIN / b);
-  else if (b == INT64_MIN)
+      return -(S_INT64_MIN / b);
+  else if (b == S_INT64_MIN)
     return 0;
   else if (signed_less_than(a, 0))
     if (signed_less_than(b, 0))
@@ -3764,7 +3776,7 @@ void get_symbol() {
           literal = ascii_to_int(integer);
 
           if (integer_is_signed)
-            if (literal > INT64_MIN) {
+            if (literal > S_INT64_MIN) {
                 syntax_error_message("signed integer out of bound");
 
                 exit(EXITCODE_SCANNERERROR);
@@ -6340,7 +6352,7 @@ uint64_t is_temporary_register(uint64_t reg) {
 void read_register_wrap(uint64_t reg, uint64_t wrap) {
   if (*(writes_per_register + reg) > 0) {
     // register has been written to before
-    if (*(reads_per_register + reg) < UINT64_MAX)
+    if (*(reads_per_register + reg) < S_US_INT64_MAX)
       *(reads_per_register + reg) = *(reads_per_register + reg) + 1;
 
     // tolerate unwrapped values in register-to-register transfers
@@ -6375,7 +6387,7 @@ void write_register_wrap(uint64_t reg, uint64_t wrap) {
     if (*(registers + REG_SP) < stack_peak)
       stack_peak = *(registers + REG_SP);
 
-  if (*(writes_per_register + reg) < UINT64_MAX)
+  if (*(writes_per_register + reg) < S_US_INT64_MAX)
     *(writes_per_register + reg) = *(writes_per_register + reg) + 1;
 }
 
@@ -10474,7 +10486,7 @@ uint64_t instruction_with_max_counter(uint64_t* counters, uint64_t max) {
   uint64_t i;
   uint64_t c;
 
-  a = UINT64_MAX;
+  a = S_US_INT64_MAX;
 
   n = 0;
   i = 0;
@@ -10493,10 +10505,10 @@ uint64_t instruction_with_max_counter(uint64_t* counters, uint64_t max) {
     i = i + 1;
   }
 
-  if (a != UINT64_MAX)
+  if (a != S_US_INT64_MAX)
     return a * INSTRUCTIONSIZE;
   else
-    return UINT64_MAX;
+    return S_US_INT64_MAX;
 }
 
 uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint64_t max) {
@@ -10505,7 +10517,7 @@ uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint6
 
   a = instruction_with_max_counter(counters, max);
 
-  if (a != UINT64_MAX) {
+  if (a != S_US_INT64_MAX) {
     c = *(counters + a / INSTRUCTIONSIZE);
 
     // CAUTION: we reset counter to avoid reporting it again
@@ -10527,7 +10539,7 @@ uint64_t print_per_instruction_counter(uint64_t total, uint64_t* counters, uint6
 
 void print_per_instruction_profile(char* message, uint64_t total, uint64_t* counters) {
   printf("%s: %s%lu", selfie_name, message, total);
-  print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, UINT64_MAX)));
+  print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, print_per_instruction_counter(total, counters, S_US_INT64_MAX)));
   println();
 }
 
@@ -11464,9 +11476,9 @@ uint64_t mixter(uint64_t* to_context, uint64_t mix) {
 
   mslice = TIMESLICE;
 
-  if (mslice <= UINT64_MAX / 100)
+  if (mslice <= S_US_INT64_MAX / 100)
     mslice = mslice * mix / 100;
-  else if (mslice <= UINT64_MAX / 10)
+  else if (mslice <= S_US_INT64_MAX / 10)
     mslice = mslice / 10 * (mix / 10);
   else
     mslice = mslice / 100 * mix;

--- a/tools/beator.c
+++ b/tools/beator.c
@@ -3027,7 +3027,7 @@ void beator(uint64_t entry_pc) {
 
     if (pc + WORDSIZE == 0)
       // check overflow to terminate loop
-      pc = UINT64_MAX;
+      pc = S_UINT64_MAX;
     else
       pc = pc + WORDSIZE;
   }

--- a/tools/beator.c
+++ b/tools/beator.c
@@ -3389,7 +3389,7 @@ uint64_t selfie_model() {
 
   if (string_compare(argument, "-")) {
     if (number_of_remaining_arguments() > 0) {
-      bad_exit_code = atoi(peek_argument(0));
+      bad_exit_code = ascii_to_int(peek_argument(0));
 
       model_arguments = 0;
 
@@ -3433,7 +3433,7 @@ uint64_t selfie_model() {
             get_argument();
 
             if (number_of_remaining_arguments() > 1) {
-              heap_allowance = round_up(atoi(peek_argument(1)), WORDSIZE);
+              heap_allowance = round_up(ascii_to_int(peek_argument(1)), WORDSIZE);
 
               get_argument();
             } else
@@ -3444,7 +3444,7 @@ uint64_t selfie_model() {
             get_argument();
 
             if (number_of_remaining_arguments() > 1) {
-              stack_allowance = round_up(atoi(peek_argument(1)), WORDSIZE);
+              stack_allowance = round_up(ascii_to_int(peek_argument(1)), WORDSIZE);
 
               get_argument();
             } else

--- a/tools/buzzr.c
+++ b/tools/buzzr.c
@@ -356,7 +356,7 @@ uint64_t selfie_buzz() {
       reset_profiler();
       reset_microkernel();
 
-      init_memory(atoi(peek_argument(0)));
+      init_memory(ascii_to_int(peek_argument(0)));
 
       run = 1;
 

--- a/tools/monster.c
+++ b/tools/monster.c
@@ -1837,14 +1837,14 @@ void monster(uint64_t* to_context) {
 uint64_t selfie_run_symbolically() {
   if (string_compare(argument, "-")) {
     if (number_of_remaining_arguments() > 0) {
-      max_execution_depth = atoi(peek_argument(0));
+      max_execution_depth = ascii_to_int(peek_argument(0));
 
       // checking for the (optional) branching limit argument
       if (number_of_remaining_arguments() > 1)
         if (string_compare(peek_argument(1), "--merge-enabled") == 0)
           if (string_compare(peek_argument(1), "--debug-merge") == 0) {
             // assert: argument is an integer representing the branching limit
-            beq_limit = atoi(peek_argument(1));
+            beq_limit = ascii_to_int(peek_argument(1));
 
             get_argument();
           }

--- a/tools/monster.c
+++ b/tools/monster.c
@@ -1626,7 +1626,7 @@ uint64_t* schedule_next_symbolic_context() {
   context = symbolic_contexts;
   max_call_stack_size = 0;
   max_call_stack = (uint64_t*) 0;
-  min_pc = UINT64_MAX;
+  min_pc = S_UINT64_MAX;
   next_context = (uint64_t*) 0;
 
   // find the currently highest call stack


### PR DESCRIPTION
This PR changes selfie in such a way that it also compiles for riscv64 gcc and runs on Unicorn.

To compile on a riscv64 cross compiler: `riscv64-unknown-elf-gcc selfie.c -o selfie-riscv.o -no-pie -include "stdlib.h" -include "stdio.h" -include "unistd.h" -include "fcntl.h"`
The resulting `selfie-riscv.o` runs on Unicorn.

Changes:

Changes to compiler flags:
- include `stdint.h`
- include `unistd.h`
- include `fcntl.h`
- remove `D'uint64_t=unsigned long'` option (covered by `stdint.h`)
- add `-Wno-sign-compare -Wno-unused-result` flags (should not interfere with student assignments)

Changed constants (due to conflict with header files):
- `UINT64_MAX` to `S_UINT64_MAX` (conflict in `stdint.h`)
- `INT64_MIN` to `S_INT64_MIN` (conflict in `stdint.h`)
- `INT64_MAX` to `S_INT64_MAX` (conflict in `stdint.h`)
- `O_RDONLY` to `F_O_RDONLY `

Changed method names (due to conflict with header files):
- `atoi` to `ascii_to_int`
- `itoa` to `int_to_ascii`