### PR TITLE
Building Docker image fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV CFLAGS="-fstack-protector -fstack-protector-explicit -U_FORTIFY_SOURCE" \
 RUN mkdir -p $RISCV \
   && mkdir -p riscv-pk/build \
   && cd riscv-pk/build \
-  && ../configure --prefix=$RISCV --host=riscv64-linux-gnu \
+  && ../configure --prefix=$RISCV --host=riscv64-linux-gnu --with-arch=rv64gc --with-abi=lp64d \
   && make \
   && make install \
   && mv $RISCV/riscv64-linux-gnu $RISCV/riscv64-unknown-elf


### PR DESCRIPTION
Docker build did not work any more, because off the last commit on "riscv-software-src/riscv-pk".
There was a change in Makefile.in, which results in a different compile switch configuration.

Fixed it by explicitly setting configuration switches to the defaults of RISCV-GCC delivered with Ubuntu,
which where used before.

Other option would be to checkout tagged version v1.0.0 of RISCV-PK. But then this change must be undone,
because the used options do not work on earlier commits of PK.