### PR TITLE
line 9 augmented '\s' removed from string

### DIFF
--- a/grader/lib/output_processing.py
+++ b/grader/lib/output_processing.py
@@ -6,7 +6,7 @@ sys.setrecursionlimit(5000)
 STATUSMESSSAGE_START = r'([a-zA-Z]:\\|(>+ )?(./)?selfie)'
 
 def contains_name(output):
-    result = re.match(STATUSMESSSAGE_START + r'[^\n]*This is \S* \S*\'s Selfie![^\n]*\n', output) != None
+    result = re.match(STATUSMESSSAGE_START + r'[^\n]*This is \S* \S* Selfie![^\n]*\n', output) != None
 
     return (result, 'The selfie output does not contain "<selfiename>: This is <firstname> <secondname>\'s Selfie!"')
 


### PR DESCRIPTION
this bug caused users with the last letter of their last name ending with 's' to return an error. This way anyone can grammatically display their name with no issue.