### PR TITLE
feat: support bootloading of binaries produced by gcc

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -7421,9 +7421,6 @@ uint64_t validate_elf_header(uint64_t fd, uint64_t* header) {
   // must match binary bootstrapping
   data_start = round_up(code_start + code_size, p_align);
 
-  printf("%s: code_start = 0x%lx\tcode_size = 0x%lx\n", selfie_name, code_start, code_size);
-  printf("%s: data_start = 0x%lx, data_size = 0x%lx\n", selfie_name, data_start, data_size);
-
   if (code_size > MAX_CODE_SIZE)
     return 0;
 

--- a/selfie.c
+++ b/selfie.c
@@ -7492,7 +7492,7 @@ void selfie_output(char* filename) {
   // assert: p_offset = 0x1000 = 4096
   // pad until code segment start
   padding_size = round_up(ELF_header_size, p_align) - ELF_header_size;
-  zeros = zmalloc(padding_size);
+  zeros = touch(zmalloc(padding_size), padding_size);
   if (write(fd, zeros, padding_size) != padding_size) {
     printf("%s: could not write padding after ELF header into binary output file %s\n", selfie_name, binary_name);
 
@@ -7534,7 +7534,7 @@ void selfie_load() {
   uint64_t* ELF_header;
   uint64_t number_of_read_bytes;
   uint64_t code_size_with_padding;
-  uint64_t* dummy;
+  uint64_t* drain;
 
   binary_name = get_argument();
 
@@ -7564,10 +7564,10 @@ void selfie_load() {
     if (validate_elf_header(fd, ELF_header)) {
       // assert: p_offset is init, and is offset into file where code starts
       // use dummy to seek into file where code segment begins
-      dummy = (uint64_t*) malloc(p_offset);
+      drain = touch(zmalloc(p_offset), p_offset);
 
       fd = open_read_only(binary_name);
-      number_of_read_bytes = read(fd, dummy, p_offset);
+      number_of_read_bytes = read(fd, drain, p_offset);
 
       init_target();
 

--- a/selfie.c
+++ b/selfie.c
@@ -7563,8 +7563,7 @@ void selfie_load() {
 
         if (number_of_read_bytes == data_size) {
           // check if we are really at EOF
-          number_of_read_bytes = read(fd, binary_buffer, sizeof(uint64_t));
-          if (number_of_read_bytes == 0) {
+          if (read(fd, binary_buffer, sizeof(uint64_t)) == 0) {
             printf("%s: %lu bytes with %lu %lu-bit RISC-U instructions and %lu bytes of data loaded from %s\n",
               selfie_name,
               ELF_HEADER_SIZE + code_size + data_size,
@@ -7576,6 +7575,13 @@ void selfie_load() {
             return;
           } else {
             printf("%s: binary loaded, but not at the end of file. Binary not produced by selfie?\n", selfie_name);
+            printf("%s: %lu bytes with (approx.) %lu %lu-bit RISC-U instructions and %lu bytes of data loaded from %s\n",
+              selfie_name,
+              ELF_HEADER_SIZE + code_size + data_size,
+              code_size / INSTRUCTIONSIZE,
+              WORDSIZEINBITS,
+              data_size,
+              binary_name);
 
             return;
           }


### PR DESCRIPTION
# Work in progres...

This PR aims to extend the boot loader of `selfie` such that it can load binaries produced both by `selfie` and `gcc`. 

The changes introduced in this PR include reading the number of page header entries and reading them in separate page table. It seems like `gcc` produces three segments, one of which is machine specific `RISCV_ATTRIBUT`, and the other two are code and data segments. 

Boot loader now extracts needed information from ELF header, like entry, code segment offset in file and so on. This is necessary, because `gcc` sets these differently from selfie. 

## How to produce RISC-V Binary with `gcc`? 

To produce RISC-V Binary using `gcc` you need to install [RISC-V GNU Compiler Toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain). You can do so with [Homebrew](https://brew.sh/) on macos, using this formula: [homebrew-riscv](https://github.com/riscv-software-src/homebrew-riscv).

Then, compile your binary using `riscv64-unknown-elf-gcc` binary. For example, you can compile `selfie` like this:

```bash
riscv64-unknown-elf-gcc -Wall -Wextra -D'uint64_t=unsigned long' -static selfie.c -o selfie_riscv
```

Then simply load the binary: 

```sh
# assuming you compiled selfie with 'make selfie'
./selfie -l selfie_riscv
```

If you try to run it in the current state, unknown instruction exception will be reported. For debugging purposes binary representation of the instruction is printed as well. You can copy the instruction and paste it in [RISC-V Instruction Encoder/Decoder](https://luplab.gitlab.io/rvcodecjs/) to see what the instruction is.