### PR TITLE
Support multiple words for last name

### DIFF
--- a/grader/lib/output_processing.py
+++ b/grader/lib/output_processing.py
@@ -6,7 +6,7 @@ sys.setrecursionlimit(5000)
 STATUSMESSSAGE_START = r'([a-zA-Z]:\\|(>+ )?(./)?selfie)'
 
 def contains_name(output):
-    result = re.match(STATUSMESSSAGE_START + r'[^\n]*This is \S* \S*\'s Selfie![^\n]*\n', output) != None
+    result = re.match(STATUSMESSSAGE_START + r'[^\n]*This is \S*(?: \S+)*\'s Selfie![^\n]*\n', output) != None
 
     return (result, 'The selfie output does not contain "<selfiename>: This is <firstname> <secondname>\'s Selfie!"')
 


### PR DESCRIPTION
In the previous implementation multiple words were not supported for the last name. Made a quick change to the expression to fix this (this automatically applies to multiple first names as well due to the nature of the expression).