### PR TITLE
fix: report commit hash error even in quiet mode

### DIFF
--- a/grader/lib/cli.py
+++ b/grader/lib/cli.py
@@ -277,7 +277,7 @@ def do_bulk_grading(assignment: Optional[Assignment], baseline: List[Assignment]
                     print_message('', loud=True)
             else:
                 print_message(
-                    'commit hash "{}" is not valid'.format(info['commit']))
+                    'commit hash "{}" is not valid'.format(info['commit']), loud=True)
 
             os.chdir(bulk_grade_directory)
 


### PR DESCRIPTION
When running grader in bulk mode, it's useful to run it in quiet mode to see just the grade with no other noise. However, in quiet mode the error on invalid commit hash is not reported and even the newline is missing. The next evaluated repository is then simply printed out in the same line. 

This makes the results harder to parse both visually and programmatically. This PR introduces a simple change to report the invalid commit hash also in quiet mode, similarly to the `error when cloning...`.

The report now looks like the following: 

```
nfejzic/myselfie: commit hash "1e1cded6b72827e8d0efda6b84db3442fbf272a7" is not valid
next/repo: ...

# instead of 
nfejzic/myselfie: next/repo: ...
```