### PR TITLE
Add missing compilable check to array target

### DIFF
--- a/grader/self.py
+++ b/grader/self.py
@@ -175,7 +175,9 @@ def check_lazy_evaluation() -> List[Check]:
 
 def check_array() -> List[Check]:
     return check_compilable('global-declaration.c',
-                            'array declaration do compile') + \
+                            'global array declaration do compile') + \
+        check_compilable('local-declaration.c',
+                         'local array declaration do compile') + \
         check_compilable('assignment.c',
                          'assignments on arrays do compile') + \
         check_compilable('invalid-assignment.c',


### PR DESCRIPTION
Although the [`local-declaration.c`](https://github.com/cksystemsteaching/selfie/blob/main/grader/assignments/array/local-declaration.c) exists in the grader, it is not used in the `[array]` grader target. I assume this unintentional, so here is the small fix. If this is indeed intentional, feel free to just close this PR.