### PR TITLE
Only halt model evaluation on exit syscall

### DIFF
--- a/tools/rotor.c
+++ b/tools/rotor.c
@@ -12422,7 +12422,7 @@ void eval_multicore_states() {
 
     if (eval_multicore_sequential()) {
       if (number_of_cores > 1) {
-        printf("%s: %s called exit on all cores after %lu steps (up to %lu instructions)", selfie_name,
+        printf("%s: %s halted on all cores after %lu steps (up to %lu instructions)", selfie_name,
           model_name, current_step - current_offset, next_step - current_offset);
         if (any_input) printf(" with input %lu\n", current_input); else printf("\n");
       }
@@ -12467,7 +12467,7 @@ uint64_t eval_constant_propagation() {
   }
 
   if (eval_multicore_sequential()) {
-    printf("%s: %s called exit on all cores already after 1 step\n", selfie_name, model_name);
+    printf("%s: %s halted on all cores already after 1 step\n", selfie_name, model_name);
 
     return 1;
   }
@@ -12630,7 +12630,7 @@ void print_unrolled_model() {
     if (eval_multicore_sequential()) {
       close_model_file();
 
-      printf("%s: %s called exit on all cores after %lu steps (up to %lu instructions)\n", selfie_name,
+      printf("%s: %s halted on all cores after %lu steps (up to %lu instructions)\n", selfie_name,
         model_name, current_step - current_offset, next_step - current_offset);
 
       return;

--- a/tools/rotor.c
+++ b/tools/rotor.c
@@ -12289,13 +12289,21 @@ uint64_t eval_multicore_sequential() {
 
   while (core < number_of_cores) {
     if (eval_sequential(core)) {
-      printf("%s: %s called exit(%lu) on core-%lu @ 0x%lX after %lu steps (up to %lu instructions)", selfie_name,
-        model_name,
-        eval_line(load_register_value(NID_A0, "exit code", get_for(core, state_register_file_nids))),
-        core,
-        eval_line_for(core, state_pc_nids),
-        current_step - current_offset,
-        next_step - current_offset);
+      if (ID_ECALL == eval_line_for(core, eval_ID_nids))
+        printf("%s: %s called exit(%lu) on core-%lu @ 0x%lX after %lu steps (up to %lu instructions)", selfie_name,
+          model_name,
+          eval_line(load_register_value(NID_A0, "exit code", get_for(core, state_register_file_nids))),
+          core,
+          eval_line_for(core, state_pc_nids),
+          current_step - current_offset,
+          next_step - current_offset);
+      else
+        printf("%s: %s halted due to no state change on core-%lu @ 0x%lX after %lu steps (up to %lu instructions)", selfie_name,
+          model_name,
+          core,
+          eval_line_for(core, state_pc_nids),
+          current_step - current_offset,
+          next_step - current_offset);
       if (any_input) printf(" with input %lu\n", current_input); else printf("\n");
     } else
       halt = 0;


### PR DESCRIPTION
Rotor currently has a bug where single-instruction infinite loops are wrongly detected as exit syscalls:
```
0x100E8: addi a0,zero,42
0x100EC: jal zero,0x100EC <0>
./rotor: infinite-loop-rotorized.btor2 called exit(42) on core-0 @ 0x100EC after 2 steps
```

This happens because `eval_sequential` will indicate that the program has halted iff there is no state change after the execution of the current instruction. As far as I can tell, this only affects exit syscalls and trivial infinite loops like the one above. Therefore, I addressed this issue by changing the halting condition to a check if the current instruction is an exit syscall. With this change, such infinite loops do not get any special treatment and simply run until the timeout limit:

```
0x100EC: jal zero,0x100EC <0>
./rotor: terminating infinite-loop-rotorized.btor2 after 100000 steps
```

Alternatively, both of these checks could be combined to indicate whether the model evaluation was terminated due to a lack of state change or an actual exit syscall. However, I'm not sure if there is any practical use for detecting these trivial infinite loops in the model evaluation.