### PR TITLE
Adding new logical operator test in grader

### DIFF
--- a/grader/assignments/logical/precedence2.c
+++ b/grader/assignments/logical/precedence2.c
@@ -1,0 +1,3 @@
+int main(int argc, char** argv) {
+  return (1 || 42 && !1) + 41;
+}

--- a/grader/self.py
+++ b/grader/self.py
@@ -140,6 +140,8 @@ def check_logical_and_or_not() -> List[Check]:
         check_mipster_execution('advanced-logical-expressions.c', 42,
                                 'advanced boolean expressions work when executed with MIPSTER') + \
         check_mipster_execution('precedence.c', 42,
+                                'operator precedence works correctly when executed with MIPSTER') + \
+        check_mipster_execution('precedence2.c', 42,
                                 'operator precedence works correctly when executed with MIPSTER')
 
 


### PR DESCRIPTION
Similar to bitwise-and-or-not: The current grader does not always recognise incorrect operator precedence of && and ||.