### PR TITLE
fix: LHS of pointer assignments can only be pointer arithmetic operations

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -49,7 +49,7 @@ value      = integer | character .
 
 statement  = assignment ";" | if | while | call ";" | return ";" .
 
-assignment = ( [ "*" ] identifier | "*" "(" expression ")" ) "=" expression .
+assignment = ( [ "*" ] identifier | "*" "(" arithmetic ")" ) "=" expression .
 
 expression = arithmetic [ ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) arithmetic ] .
 

--- a/selfie.c
+++ b/selfie.c
@@ -4886,7 +4886,7 @@ void compile_assignment(char* variable) {
       get_symbol();
 
       // load expression value (as address)
-      ltype = compile_expression();
+      ltype = compile_arithmetic();
 
       get_expected_symbol(SYM_RPARENTHESIS);
     } else {


### PR DESCRIPTION
In `compile_assignment` the `ltype` is an expression and can be changed to `ltype = compile_arithmetic()` as we only have pointer arithmetic or identifier dereferencing on the left hand side of assignments in C*. The default implementation from selfie compiles this with only warnings and no errors:

```
int main() {
    int *x;
    int *y;

    *(x == y) = 12;

    return 0;
}
```

Although running this results in a segfault, I find that compiling it successfully is also not ideal. Changing it to `ltype = compile_arithmetic()` in `compile_assignment`, the self compilation doesn't break under `make self` and `make self-self` and it returns syntax error when above code is now tried to compile.