### PR TITLE
Split array assignment

### DIFF
--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -19,7 +19,8 @@ on:
         - bitwise-shift-compilation
         - bitwise-shift-execution
         - bitwise-and-or-not
-        - array
+        - array-access
+        - array-allocation
         - array-multidimensional
         - struct-declaration
         - struct-execution

--- a/assignments/compiler-assignments.md
+++ b/assignments/compiler-assignments.md
@@ -104,14 +104,13 @@ Change the Boolean operators `&&`, `||`, and `!` such that lazy evaluation is us
 
 
 
-## Assignment `array`:
+## Assignment `array-allocation`:
 
-Implement support of and code generation for one-dimensional arrays in C\* with the symbols `[` and `]`.
+Implement support for allocation of one-dimensional arrays in C\* with the symbols `[` and `]`.
 
-- Before coding, extend the grammar in **grammar.md** to include `[` and `]`.
+- Before coding, extend the grammar in **grammar.md** to include `[` and `]` for declaration.
 - Do not modify any files other than **grammar.md** and **selfie.c**.
-- Use the `array` target in the grader to determine your grade.
-
+- Use the `array-allocation` target in the grader to determine your grade.
 
 
 ## Assignment `array-multidimensional`:

--- a/assignments/compiler-assignments.md
+++ b/assignments/compiler-assignments.md
@@ -104,6 +104,16 @@ Change the Boolean operators `&&`, `||`, and `!` such that lazy evaluation is us
 
 
 
+## Assignment `array-access`:
+
+Implement support of and code generation for array access on pointers in C\* with the symbols `[` and `]`.
+
+- Before coding, extend the grammar in **grammar.md** to include `[` and `]` for access.
+- Do not modify any files other than **grammar.md** and **selfie.c**.
+- Use the `array-access` target in the grader to determine your grade.
+
+
+
 ## Assignment `array-allocation`:
 
 Implement support for allocation of one-dimensional arrays in C\* with the symbols `[` and `]`.

--- a/grader/assignments/array/assign.c
+++ b/grader/assignments/array/assign.c
@@ -1,0 +1,12 @@
+int main(int argc, char** argv) {
+  uint64_t* arr;
+
+  arr = malloc(sizeof(uint64_t) * 4);
+
+  arr[0] = 4;
+  arr[1] = 8;
+  arr[2]= 14;
+  arr[3] = 16;
+
+  return *arr + *(arr + 1) + *(arr + 2) + *(arr + 3);
+}

--- a/grader/assignments/array/use.c
+++ b/grader/assignments/array/use.c
@@ -1,0 +1,12 @@
+int main(int argc, char** argv) {
+  uint64_t* arr;
+
+  arr = malloc(sizeof(uint64_t) * 4);
+
+  *arr = 4;
+  *(arr + 1) = 8;
+  *(arr + 2) = 14;
+  *(arr + 3) = 16;
+
+  return arr[0] + arr[1] + arr[2] + arr[3];
+}

--- a/grader/self.py
+++ b/grader/self.py
@@ -177,7 +177,7 @@ def check_lazy_evaluation() -> List[Check]:
                                 'lazy evaluation with logical or works when executed with MIPSTER')
 
 
-def check_array() -> List[Check]:
+def check_array_allocation() -> List[Check]:
     return check_compilable('global-declaration.c',
                             'global array declaration do compile') + \
         check_compilable('local-declaration.c',
@@ -382,12 +382,12 @@ assignment_for_loop = Assignment('for-loop', 'Compiler', 'for-loop',
 assignment_lazy_evaluation = Assignment('lazy-evaluation', 'Compiler', 'logical',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-lazy-evaluation',
            check_lazy_evaluation, parent = assignment_logical_and_or_not)
-assignment_array = Assignment('array', 'Compiler', 'array',
-           REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array',
-           check_array)
+assignment_array_allocation = Assignment('array-allocation', 'Compiler', 'array',
+           REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array-allocation',
+           check_array_allocation)
 assignment_multidimensional_array = Assignment('array-multidimensional', 'Compiler', 'array',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array-multidimensional',
-           check_multidimensional_array, parent = assignment_array)
+           check_multidimensional_array, parent = assignment_array_allocation)
 assignment_struct_declaration = Assignment('struct-declaration', 'Compiler', 'struct',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-struct-declaration',
            check_struct_declaration)
@@ -431,7 +431,7 @@ assignments: List[Assignment] = [
     assignment_logical_and_or_not,
     assignment_for_loop,
     assignment_lazy_evaluation,
-    assignment_array,
+    assignment_array_allocation,
     assignment_multidimensional_array,
     assignment_struct_declaration,
     assignment_struct_execution,

--- a/grader/self.py
+++ b/grader/self.py
@@ -177,6 +177,17 @@ def check_lazy_evaluation() -> List[Check]:
                                 'lazy evaluation with logical or works when executed with MIPSTER')
 
 
+def check_array_access() -> List[Check]:
+    return check_compilable('use.c',
+                            'array use does compile') + \
+        check_compilable('assign.c',
+                        'array assignment does compile') + \
+        check_mipster_execution('use.c', 42,
+                                'array use is implemented with the right semantics') + \
+        check_mipster_execution('assign.c', 42,
+                                'array assignment is implemented with the right semantics')
+
+
 def check_array_allocation() -> List[Check]:
     return check_compilable('global-declaration.c',
                             'global array declaration do compile') + \
@@ -382,9 +393,12 @@ assignment_for_loop = Assignment('for-loop', 'Compiler', 'for-loop',
 assignment_lazy_evaluation = Assignment('lazy-evaluation', 'Compiler', 'logical',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-lazy-evaluation',
            check_lazy_evaluation, parent = assignment_logical_and_or_not)
+assignment_array_access = Assignment('array-access', 'Compiler', 'array',
+           REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array-access',
+           check_array_access)
 assignment_array_allocation = Assignment('array-allocation', 'Compiler', 'array',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array-allocation',
-           check_array_allocation)
+           check_array_allocation, parent = assignment_array_access)
 assignment_multidimensional_array = Assignment('array-multidimensional', 'Compiler', 'array',
            REPO_BLOB_BASE_URI + 'grader/compiler-assignments.md#assignment-array-multidimensional',
            check_multidimensional_array, parent = assignment_array_allocation)
@@ -431,6 +445,7 @@ assignments: List[Assignment] = [
     assignment_logical_and_or_not,
     assignment_for_loop,
     assignment_lazy_evaluation,
+    assignment_array_access,
     assignment_array_allocation,
     assignment_multidimensional_array,
     assignment_struct_declaration,


### PR DESCRIPTION
Ths splits the array assignment into two assignments:

### array-access
- Requires implementing array subscripting for pointers (assignment and use)

### array-allocation
- Requires implementing arrays as a supported data structure
- This is the same as the old array assignment
