### PR TITLE
fix: local/global variable redefinitions now cause syntax errors

### DIFF
--- a/selfie.c
+++ b/selfie.c
@@ -4456,7 +4456,7 @@ void check_variable_redefinition(uint64_t scope, char* variable) {
     return;
 
   print_line_number("syntax error", line_number);
-  printf("redefinition of variable '%s', original definition present on line %ld\n", get_string(entry), get_line_number(entry));
+  printf("redefinition of variable %s, original definition in line %lu\n", get_string(entry), get_line_number(entry));
 
   number_of_syntax_errors = number_of_syntax_errors + 1;
 }

--- a/selfie.c
+++ b/selfie.c
@@ -697,6 +697,7 @@ void syntax_error_unexpected_symbol();
 uint64_t get_expected_symbol(uint64_t expected_symbol);
 void     get_required_symbol(uint64_t required_symbol);
 
+void check_variable_redefinition(uint64_t scope, char* variable);
 void syntax_error_undeclared_identifier(char* name);
 void syntax_error_unexpected_identifier(char* expected);
 
@@ -4441,6 +4442,25 @@ void get_required_symbol(uint64_t required_symbol) {
     exit(EXITCODE_PARSERERROR);
 }
 
+void check_variable_redefinition(uint64_t scope, char* variable) {
+  uint64_t* entry;
+
+  assert(and(variable != (char*) 0, or(scope == GLOBAL_TABLE, scope == LOCAL_TABLE)), __LINE__, __func__);
+
+  if (scope == GLOBAL_TABLE)
+    entry = search_global_symbol_table(variable, VARIABLE);
+  else
+    entry = search_local_symbol_table(variable);
+
+  if (entry == (uint64_t*) 0)
+    return;
+
+  print_line_number("syntax error", line_number);
+  printf("redefinition of variable '%s', original definition present on line %ld\n", get_string(entry), get_line_number(entry));
+
+  number_of_syntax_errors = number_of_syntax_errors + 1;
+}
+
 void syntax_error_undeclared_identifier(char* name) {
   print_line_number("syntax error", line_number);
   printf("%s undeclared\n", name);
@@ -4553,25 +4573,20 @@ uint64_t* compile_variable(char* variable, uint64_t type, uint64_t offset) {
     // lookahead of 1: identifier already parsed into variable (type may be left-factored)
 
     // global variable
-    entry = search_global_symbol_table(variable, VARIABLE);
+    check_variable_redefinition(GLOBAL_TABLE, variable);
 
-    if (entry == (uint64_t*) 0) {
-      // allocate memory for global variable in data segment
-      data_size = data_size + WORDSIZE;
+    // allocate memory for global variable in data segment
+    data_size = data_size + WORDSIZE;
 
-      entry = create_symbol_table_entry(GLOBAL_TABLE, variable,
-        line_number, VARIABLE, type, 0, -data_size);
+    entry = create_symbol_table_entry(GLOBAL_TABLE, variable,
+      line_number, VARIABLE, type, 0, -data_size);
 
-      number_of_global_variables = number_of_global_variables + 1;
-    } else {
-      // global variable already declared or defined
-      print_line_number("warning", line_number);
-      printf("redefinition of global variable %s ignored\n", variable);
-    }
+    number_of_global_variables = number_of_global_variables + 1;
   } else {
     // local variable or formal parameter
     if (symbol == SYM_IDENTIFIER) {
-      // TODO: check if identifier has already been declared
+      check_variable_redefinition(LOCAL_TABLE, identifier);
+
       entry = create_symbol_table_entry(LOCAL_TABLE, identifier,
         line_number, VARIABLE, type, 0, offset);
 


### PR DESCRIPTION
fixed a TODO on line 4574 previously in `selfie.c` which mentions about checking local variable redefinitions as well. Now both local and global variables cannot be redefined similar to C.