### PR TITLE
fix: correct Falied->Failed typo in results deserialization error message

### DIFF
--- a/tools/periscope/periscope-rs/src/bench/mod.rs
+++ b/tools/periscope/periscope-rs/src/bench/mod.rs
@@ -276,7 +276,7 @@ fn load_or_create_results(
 
     let results = File::open(&results_path)
         .context("Failed reading file.")
-        .and_then(|f| serde_json::from_reader(&f).context("Falied deserializing results file."))
+        .and_then(|f| serde_json::from_reader(&f).context("Failed deserializing results file."))
         .inspect_err(|err| {
             eprintln!(
                 "Deserialization of '{}' failed: {}",


### PR DESCRIPTION
Fix user-facing error message typo in tools/periscope/periscope-rs/src/bench/mod.rs.

**Before:** .context("Falied deserializing results file.")
**After:** .context("Failed deserializing results file.")

Co-authored-by: Jah-yee <jydu_seven@outlook.com>